### PR TITLE
Add environment file for conda installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+# A conda environment with all necessary packages for nectarchain developers
+name: nectarchain-dev
+channels:
+  - default
+  - cta-observatory
+dependencies:
+  - python=3.7  # nail the python version, so conda does not try upgrading / dowgrading
+  - ctapipe  # version 0.6.2 as of 15.07.2019
+  - pip
+  - pip:
+      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
+      - git+git://github.com/cta-observatory/ctapipe_io_nectarcam.git


### PR DESCRIPTION
This very simple environment file can be used to create an anaconda environment called `nectarchain-dev` with:

`conda env create -f environment.yml`

The problem at this stage is that `ctapipe` is installed directly with `conda` from the `cta-observatory` repository, i.e. using the last tagged version available, which is 0.6.2 as of today.

Installing an environment from git master by using instead:

```
# A conda environment with all necessary packages for nectarchain developers
name: nectarchain-dev
channels:
  - default
dependencies:
  - python=3.7  # nail the python version, so conda does not try upgrading / dowgrading
  - pip
  - pip:
      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
      - git+git://github.com/cta-observatory/ctapipe.git
      - git+git://github.com/cta-observatory/ctapipe_io_nectarcam.git
```
will work, but an attempt to read NectarCAM data:

```
from ctapipe.io import event_source, EventSeeker
path = 'obs/NectarCAM.Run1250.0000.fits.fz'
reader = event_source(input_url=path)
seeker = EventSeeker(reader)
currentevent = seeker[0]
```
fails with:
```
Seeking to event by looping through events... (potentially long process)
Traceback (most recent call last):
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe/io/eventseeker.py", line 182, in __getitem__
    event = self._reader._get_event_by_index(item)
AttributeError: 'NectarCAMEventSource' object has no attribute '_get_event_by_index'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe/io/eventseeker.py", line 191, in __getitem__
    event = self._get_event_by_index(item)
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe/io/eventseeker.py", line 218, in _get_event_by_index
    for event in self._source:
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe/io/eventsource.py", line 217, in __iter__
    for event in self._generator():
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe_io_nectarcam/__init__.py", line 93, in _generator
    optics = OpticsDescription.from_name("MST")
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe/instrument/optics.py", line 97, in from_name
    table = get_table_dataset(optics_table, role="dl0.tel.svc.optics")
  File "/home/jlenain/local/src/python/anaconda/envs/nectarchain-dev/lib/python3.7/site-packages/ctapipe/utils/datasets.py", line 194, in get_table_dataset
    table_name, ', '.join(types_to_try)))
FileNotFoundError: couldn't locate table: optics[.fits.gz, .fits, .ecsv, .ecsv.txt]
```

Since this is presumably related to advancements in `ctapipe` itself rather than from the `conda` installation proposed here, maybe the best option is still to propose a `conda` installation using the git master code of `ctapipe`.

@FrancaCassol , @bregeon , @sizun,  what do you think ?