### PR TITLE
Updating protozfitsreader version to read native charges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd nectarchain
 conda env create --name cta --file environment.yml
 source activate cta
 pip install https://github.com/cta-observatory/ctapipe/archive/master.tar.gz
-pip install https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
+pip install https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz
 pip install https://github.com/cta-observatory/ctapipe_io_nectarcam/archive/master.tar.gz
 pip install -e .
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - pip:
       - pytest_runner
       - pytest-ordering
-      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
+      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz


### PR DESCRIPTION
Update to latest reader is necessary to avoid warnings when reading the latest data files and read native charges. See cta-sst-1m/protozfitsreader#62