### PR TITLE
Updated installation procedure for ctapipe-0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is how you should install:
 git clone git@github.com:cta-observatory/nectarchain.git
 cd nectarchain
 conda env create --name nectarchain --file environment.yml
-conda activate cta
+conda activate nectarchain
 cd ..
 git clone git@github.com:cta-observatory/ctapipe_io_nectarcam.git
 cd ctapipe_io_nectarcam

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here is how you should install:
 ```
 git clone git@github.com:cta-observatory/nectarchain.git
 cd nectarchain
-conda env create --name cta --file environment.yml
+conda env create --name nectarchain --file environment.yml
 conda activate cta
 cd ..
 git clone git@github.com:cta-observatory/ctapipe_io_nectarcam.git

--- a/README.md
+++ b/README.md
@@ -10,21 +10,23 @@ Current `nectarchain` build uses `ctapipe` master version.
 
 Here is how you should install:
 ```
-git clone https://github.com/cta-observatory/nectarchain.git
+git clone git@github.com:cta-observatory/nectarchain.git
 cd nectarchain
 conda env create --name cta --file environment.yml
 conda activate cta
-pip install git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
-pip install https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz
-pip install https://github.com/cta-observatory/ctapipe_io_nectarcam/archive/master.tar.gz
+cd ..
+git clone git@github.com:cta-observatory/ctapipe_io_nectarcam.git
+cd ctapipe_io_nectarcam
+pip install -e .
+cd ../nectarchain
 pip install -e .
 ```
-If you are a developper, better you install ctapipe as described in https://cta-observatory.github.io/ctapipe/getting_started/index.html
+If you are a developer, better you install ctapipe as described in https://cta-observatory.github.io/ctapipe/getting_started/index.html
 and periodically perform a "git pull upstream master" in order to be updated with the master
 
 ## Contributing
 
-All contribution are welcomed.
+All contribution are welcome.
 
 Guidelines are the same as [ctapipe's ones](https://cta-observatory.github.io/ctapipe/development/index.html)
 See [here](https://cta-observatory.github.io/ctapipe/development/pullrequests.html) how to make a pull request to contribute.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: cta
+name: nectarchain
 channels:
   - default
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,9 @@
 name: cta
 channels:
   - default
-  - cta-observatory
-  - conda-forge
 dependencies:
-  - python=3.7
-  - ctapipe
-  - gammapy
-  - pip:
-      - pytest_runner
-      - pytest-ordering
-      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz
+  - python=3.8 # nail the python version, so conda does not try upgrading / downgrading
+  - conda-forge::ctapipe=0.12
+  - jupyterlab
+  - conda-forge::protozfits=2.0
+  - pytest-runner

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,5 @@ dependencies:
   - jupyterlab
   - conda-forge::protozfits=2.0
   - pytest-runner
+  - pip
+  

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# import sys
 
 from setuptools import setup, find_packages
 from os import path
@@ -21,7 +20,6 @@ setup(
     install_requires=[
         'astropy',
         'ctapipe',
-        'protozfits @ https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz',
     ],
     tests_require=['pytest'],
     setup_requires=['pytest_runner'],


### PR DESCRIPTION
This PR proposes some change to the installation procedure of `nectarchain`, to be based on `ctapipe` 0.12, and up-to-date with the last changes made to `ctapipe_io_nectarcam` by @tibaldo (see https://github.com/cta-observatory/ctapipe_io_nectarcam/pull/18 and https://github.com/cta-observatory/ctapipe_io_nectarcam/issues/17).