### PR TITLE
Adapt environment to changes in ctapipe_io_nectarcam.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ master branch status: [![Build Status](https://travis-ci.org/cta-observatory/nec
 
 Current `nectarchain` build uses `ctapipe` master version.
 
+## Install
+
 Here is how you should install:
 ```
 git clone https://github.com/cta-observatory/nectarchain.git
 cd nectarchain
-conda env create --name cta --file environment.yml
-conda activate cta
+conda env create --name nectarchain --file environment.yml
+conda activate nectarchain
 pip install git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
-pip install https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz
-pip install https://github.com/cta-observatory/ctapipe_io_nectarcam/archive/master.tar.gz
+pip install git+https://github.com/cta-observatory/ctapipe_io_nectarcam.git#egg=ctapipe_io_nectarcam
 pip install -e .
 ```
 If you are a developper, better you install ctapipe as described in https://cta-observatory.github.io/ctapipe/getting_started/index.html

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,14 @@
-name: cta
+name: nectarchain
 channels:
   - default
   - cta-observatory
   - conda-forge
 dependencies:
-  - python=3.7
-  - ctapipe
+  - python=3.8 # nail the python version, so conda does not try upgrading / dowgrading
+  - ctapipe=0.12
   - gammapy
+  - pip
+  - protozfits~=2.0
   - pip:
       - pytest_runner
       - pytest-ordering
-      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'astropy',
-        'ctapipe',
-        'protozfits @ https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz',
+        'astropy~=4.2',
+        'ctapipe~=0.12',
+        'protozfits~=2.0',
     ],
     tests_require=['pytest'],
     setup_requires=['pytest_runner'],


### PR DESCRIPTION
This PR fixes errors installing nectarchain at least for me. Mostly consists in requiring the same version of protozfits as ctapipe_io_nectarcam, plus a few cosmetic changes. Fill free to ignore it.