### PR TITLE
Update environment.yml and setup.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.8 # nail the python version, so conda does not try upgrading / downgrading
   - conda-forge::ctapipe=0.12
+  - numpy=1.22.4 # higher versions don't work due to astropy4 dependency in ctapipe0.12
   - jupyterlab
   - conda-forge::protozfits=2.0
   - pytest-runner

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8 # nail the python version, so conda does not try upgrading / downgrading
   - conda-forge::ctapipe=0.12
-  - numpy=1.22.4 # higher versions don't work due to astropy4 dependency in ctapipe0.12
+  - numpy=1.22 # higher versions don't work due to astropy4 dependency in ctapipe0.12
   - jupyterlab
   - conda-forge::protozfits=2.0
   - pytest-runner

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8 # nail the python version, so conda does not try upgrading / downgrading
   - conda-forge::ctapipe=0.12
-  - numpy=1.22 # higher versions don't work due to astropy4 dependency in ctapipe0.12
+  - numpyy~=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - jupyterlab
   - conda-forge::protozfits=2.0
   - pytest-runner

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8 # nail the python version, so conda does not try upgrading / downgrading
   - conda-forge::ctapipe=0.12
-  - numpyy~=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
+  - numpy~=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - jupyterlab
   - conda-forge::protozfits=2.0
   - pytest-runner

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8 # nail the python version, so conda does not try upgrading / downgrading
   - conda-forge::ctapipe=0.12
-  - numpy~=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
+  - numpy=1.22 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - jupyterlab
   - conda-forge::protozfits=2.0
   - pytest-runner

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,9 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'astropy',
-        'ctapipe',
+        'astropy~=4.2',
+        'ctapipe~=0.12',
+        'numpy~=1.22.4',
     ],
     tests_require=['pytest'],
     setup_requires=['pytest_runner'],


### PR DESCRIPTION
Have to pin numpy to 1.22, as @maxnoe remarks "ctapipe 0.12 depends on astropy 4, which is incompatible with the most recent numpy release 1.23"