### PR TITLE
Switch bootstrap from miniconda3 to mambaforge for Singularity build recipe

### DIFF
--- a/singularity/nectarchain.def
+++ b/singularity/nectarchain.def
@@ -1,9 +1,9 @@
 # nectarchain.sif - A singularity image for nectarchain
 #
-# Built from miniconda, with special conda environment containing nectarchain
+# Built from mambaforge, with special conda environment containing nectarchain
 #
 # Jean-Philippe Lenain <jlenain@in2p3.fr>
-# Time-stamp: "2022-07-08 08:59:21 jlenain"
+# Time-stamp: "2022-12-15 21:33:29 jlenain"
 #
 # Typically, build this image with:
 # `sudo singularity build nectarchain.sif nectarchain.def`
@@ -12,7 +12,7 @@
 # `singularity shell nectarchain.sif`
 
 Bootstrap: docker
-From: continuumio/miniconda3
+From: condaforge/mambaforge
 
 # From https://github.com/hpcng/singularity/issues/5075#issuecomment-594391772
 %environment
@@ -29,28 +29,28 @@ From: continuumio/miniconda3
 %post
     ORIG=$PWD
     . /opt/conda/etc/profile.d/conda.sh
-    conda update --name base -c defaults conda
-    conda install --name base -c conda-forge mamba
+    . /opt/conda/etc/profile.d/mamba.sh
+    mamba update --quiet --name base conda mamba
     mkdir -p /opt/cta
     cd /opt/cta
     git clone https://github.com/cta-observatory/nectarchain.git
-    mamba env create -q --file nectarchain/environment.yml --prefix /opt/conda/envs/nectarchain
-    conda activate nectarchain
+    mamba env create --quiet --file nectarchain/environment.yml --prefix /opt/conda/envs/nectarchain
+    mamba activate nectarchain
     git clone https://github.com/cta-observatory/ctapipe_io_nectarcam.git
     cd ctapipe_io_nectarcam
     pip install -e .
     cd ../nectarchain
     pip install -e .
     mamba clean -q -y --all
-    rm -f $ORIG/environment.yml
     echo "## Activate nectarchain environment" >> /.singularity_bash
     echo "source /opt/conda/etc/profile.d/conda.sh" >> /.singularity_bash
-    echo "conda activate nectarchain" >> /.singularity_bash
+    echo "source /opt/conda/etc/profile.d/mamba.sh" >> /.singularity_bash
+    echo "mamba activate nectarchain" >> /.singularity_bash
 
 %runscript
-    echo "This is a miniconda container with a nectarchain environment"
+    echo "This is a mambaforge container with a nectarchain environment"
     exec /bin/bash --noprofile --init-file /.singularity_bash "$@"
 
 %startscript
-    echo "This is a miniconda container with a nectarchain environment"
+    echo "This is a mambaforge container with a nectarchain environment"
     exec /bin/bash --noprofile --init-file /.singularity_bash "$@"


### PR DESCRIPTION
This PR proposes to change the bootstrap image from miniconda3 to mambaforge for the Singularity build recipe, to take full advantage of `mamba` for the `nectarchain` environment creation.