### PR TITLE
Update environment-dirac.yml

### DIFF
--- a/environment-dirac.yml
+++ b/environment-dirac.yml
@@ -10,7 +10,7 @@ dependencies:
   - pytest-runner
   - pip
   - dirac-grid  # required by DIRAC
-  - diracgrid::fts3  # required by DIRAC
+  - diracgrid/label/old::fts3  # required by DIRAC
   - voms  # required by DIRAC
   - gfal2  # required by DIRAC
   - pip:


### PR DESCRIPTION
With just - diracgrid::fts3 in the environment-dirac, this gives the error `ResolvePackageNotFound:  - diracgrid::fts3`. Patrick Sizun's solution to use `diracgrid/label/old::fts3` instead in the environment-dirac works, as might be guessed from https://anaconda.org/diracgrid/fts3