### PR TITLE
Small bug in critical error in DQM submit script

### DIFF
--- a/nectarchain/user_scripts/jlenain/dqm_job_submitter/submit_dqm_processor.py
+++ b/nectarchain/user_scripts/jlenain/dqm_job_submitter/submit_dqm_processor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Time-stamp: "2023-01-30 16:21:41 jlenain"
+# Time-stamp: "2023-02-07 21:39:09 jlenain"
 
 import argparse
 import sys
@@ -93,7 +93,7 @@ for f in meta['Files']:
         sqlfile = f
 if args.run is not None:
     if args.run not in runlist:
-        logger.critical(f'Your specified run {run} was not found in {dfcDir}, aborting...')
+        logger.critical(f'Your specified run {args.run} was not found in {dfcDir}, aborting...')
         sys.exit(1)
     runlist = [args.run]
     


### PR DESCRIPTION
Wrong `run` given in `logging.CRITICAL`.