### PR TITLE
Flake8 formatting

### DIFF
--- a/src/nectarchain/dqm/ReadPickleFiles.py
+++ b/src/nectarchain/dqm/ReadPickleFiles.py
@@ -4,9 +4,7 @@ import sys
 
 filename = sys.argv[1]
 
-infile = open(filename,'rb')
+infile = open(filename, 'rb')
 new_dict = pickle.load(infile)
 infile.close()
 print(new_dict)
-
-

--- a/src/nectarchain/dqm/camera_monitoring.py
+++ b/src/nectarchain/dqm/camera_monitoring.py
@@ -1,8 +1,10 @@
-
-from dqm_summary_processor import *
-import math
+from dqm_summary_processor import dqm_summary
+from matplotlib import pyplot as plt
+from ctapipe.visualization import CameraDisplay
+from ctapipe.instrument import CameraGeometry
+from astropy import time as astropytime
+import numpy as np
 import sqlite3
-import os
 
 
 class CameraMonitoring(dqm_summary):
@@ -12,11 +14,10 @@ class CameraMonitoring(dqm_summary):
         self.k = gaink
         return None
 
-    def ConfigureForRun(self,path, Chan, Samp, Reader1):
-        #define number of channels and samples
+    def ConfigureForRun(self, path, Chan, Samp, Reader1):
+        # define number of channels and samples
         self.Chan = Chan
-        self.Samp= Samp
-
+        self.Samp = Samp
 
         self.camera = CameraGeometry.from_name("NectarCam", 3)
         self.cmap = 'gnuplot2'
@@ -27,23 +28,25 @@ class CameraMonitoring(dqm_summary):
         self.event_times = []
 
         for i, evt1 in enumerate(Reader1):
-            self.run_start1= evt1.nectarcam.tel[0].svc.date 
+            self.run_start1 = evt1.nectarcam.tel[0].svc.date
 
-        SqlFileDate = (astropytime.Time(self.run_start1, format='unix').iso).split(" ")[0]
+        SqlFileDate = (astropytime.Time(
+            self.run_start1, format='unix'
+        ).iso).split(" ")[0]
 
         SqlFilePath = ""
-        for i in range(len(path.split("/"))-1):
-            SqlFilePath = SqlFilePath  +  path.split("/")[i] + "/"
+        for i in range(len(path.split("/")) - 1):
+            SqlFilePath = SqlFilePath + path.split("/")[i] + "/"
 
         SqlFileName = SqlFilePath + "nectarcam_monitoring_db_" + SqlFileDate + ".sqlite"
         print("SqlFileName", SqlFileName)
 
-        con = sqlite3.connect(SqlFileName) 
-        cursor = con.cursor()  
-        #print(cursor.fetchall())
+        con = sqlite3.connect(SqlFileName)
+        cursor = con.cursor()
+        # print(cursor.fetchall())
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
-        TempData=cursor.execute('''SELECT * FROM monitoring_drawer_temperatures''')
-        #print(TempData.description)
+        # TempData = cursor.execute('''SELECT * FROM monitoring_drawer_temperatures''')
+        # print(TempData.description)
 
         self.DrawerTemp = cursor.fetchall()
         cursor.close()
@@ -55,8 +58,6 @@ class CameraMonitoring(dqm_summary):
         self.event_times.append(trigger_time)
         self.event_id.append(trigger_id)
 
-
-
     def FinishRun(self):
 
         self.event_id = np.array(self.event_id)
@@ -66,91 +67,96 @@ class CameraMonitoring(dqm_summary):
         self.run_end = np.max(self.event_times) + 100
 
         self.DrawerTemp = np.array(self.DrawerTemp)
-        self.DrawerTimes = np.array(self.DrawerTemp[:,3])
+        self.DrawerTimes = np.array(self.DrawerTemp[:, 3])
 
         for i in range(len(self.DrawerTimes)):
-            self.DrawerTimes[i] = astropytime.Time(self.DrawerTimes[i], format = 'iso').unix
+            self.DrawerTimes[i] = astropytime.Time(
+                self.DrawerTimes[i], format='iso'
+            ).unix
 
-
-        self.DrawerTemp11 = self.DrawerTemp[:,4][self.DrawerTimes > self.run_start]
-        self.DrawerTemp21 = self.DrawerTemp[:,5][self.DrawerTimes > self.run_start]
-        self.DrawerNum1 = self.DrawerTemp[:,2][self.DrawerTimes > self.run_start]
+        self.DrawerTemp11 = self.DrawerTemp[:, 4][self.DrawerTimes > self.run_start]
+        self.DrawerTemp21 = self.DrawerTemp[:, 5][self.DrawerTimes > self.run_start]
+        self.DrawerNum1 = self.DrawerTemp[:, 2][self.DrawerTimes > self.run_start]
 
         self.DrawerTimes_new = self.DrawerTimes[self.DrawerTimes > self.run_start]
 
         self.DrawerTemp12 = self.DrawerTemp11[self.DrawerTimes_new < self.run_end]
         self.DrawerTemp22 = self.DrawerTemp21[self.DrawerTimes_new < self.run_end]
-        self.DrawerNum2 = self.DrawerNum1[self.DrawerTimes_new < self.run_end]   
+        self.DrawerNum2 = self.DrawerNum1[self.DrawerTimes_new < self.run_end]
 
         self.DrawerTemp1_mean = []
         self.DrawerTemp2_mean = []
         TotalDrawers = np.max(self.DrawerNum2)
 
-        for i in range(TotalDrawers+1):
+        for i in range(TotalDrawers + 1):
             for j in range(7):
-                self.DrawerTemp1_mean.append(np.mean(self.DrawerTemp12[self.DrawerNum2 == i]))
-                self.DrawerTemp2_mean.append(np.mean(self.DrawerTemp22[self.DrawerNum2 == i]))
+                self.DrawerTemp1_mean.append(np.mean(
+                    self.DrawerTemp12[self.DrawerNum2 == i])
+                )
+                self.DrawerTemp2_mean.append(np.mean(
+                    self.DrawerTemp22[self.DrawerNum2 == i]
+                ))
         self.DrawerTemp1_mean = np.array(self.DrawerTemp1_mean)
         self.DrawerTemp2_mean = np.array(self.DrawerTemp2_mean)
 
-        self.DrawerTemp_mean = (self.DrawerTemp1_mean + self.DrawerTemp2_mean)/2
-
+        self.DrawerTemp_mean = (self.DrawerTemp1_mean + self.DrawerTemp2_mean) / 2
 
     def GetResults(self):
         self.CameraMonitoring_Results_Dict = {}
-        self.CameraMonitoring_Results_Dict["CAMERA-TEMPERATURE-AVERAGE"] = self.DrawerTemp_mean
+        self.CameraMonitoring_Results_Dict[
+            "CAMERA-TEMPERATURE-AVERAGE"
+        ] = self.DrawerTemp_mean
 
         return self.CameraMonitoring_Results_Dict
 
-    def PlotResults(self,name,FigPath):
-        self.ChargeInt_Figures_Dict={}
+    def PlotResults(self, name, FigPath):
+        self.ChargeInt_Figures_Dict = {}
         self.ChargeInt_Figures_Names_Dict = {}
 
         fig, disp = plt.subplots()
         disp = CameraDisplay(self.camera)
         disp.image = self.DrawerTemp_mean
         disp.cmap = plt.cm.coolwarm
-        disp.axes.text(1.8, -0.3, 'Temperature', fontsize=12,rotation=90)
+        disp.axes.text(1.8, -0.3, 'Temperature', fontsize=12, rotation=90)
         disp.add_colorbar()
         plt.title("Camera temperature average")
         full_name = name + '_CameraTemperature_Mean.png'
-        FullPath = FigPath +full_name
+        FullPath = FigPath + full_name
         self.ChargeInt_Figures_Dict["CAMERA-TEMPERATURE-IMAGE-AVERAGE"] = fig
         self.ChargeInt_Figures_Names_Dict["CAMERA-TEMPERATURE-IMAGE-AVERAGE"] = FullPath
 
         plt.close()
 
-
-
         fig1, disp = plt.subplots()
         disp = CameraDisplay(self.camera)
         disp.image = self.DrawerTemp1_mean
         disp.cmap = plt.cm.coolwarm
-        disp.axes.text(1.8, -0.3, 'Temperature 1', fontsize=12,rotation=90)
+        disp.axes.text(1.8, -0.3, 'Temperature 1', fontsize=12, rotation=90)
         disp.add_colorbar()
         plt.title("Camera temperature average 1")
         full_name = name + '_CameraTemperature_average1.png'
-        FullPath = FigPath +full_name
+        FullPath = FigPath + full_name
         self.ChargeInt_Figures_Dict["CAMERA-TEMPERATURE-IMAGE-AVERAGE-1"] = fig1
-        self.ChargeInt_Figures_Names_Dict["CAMERA-TEMPERATURE-IMAGE-AVERAGE-1"] = FullPath
+        self.ChargeInt_Figures_Names_Dict[
+            "CAMERA-TEMPERATURE-IMAGE-AVERAGE-1"
+        ] = FullPath
 
         plt.close()
-
-
 
         fig2, disp = plt.subplots()
         disp = CameraDisplay(self.camera)
         disp.image = self.DrawerTemp2_mean
         disp.cmap = plt.cm.coolwarm
-        disp.axes.text(1.8, -0.3, 'Temperature 2', fontsize=12,rotation=90)
+        disp.axes.text(1.8, -0.3, 'Temperature 2', fontsize=12, rotation=90)
         disp.add_colorbar()
         plt.title("Camera temperature average 2")
         full_name = name + '_CameraTemperature_average2.png'
-        FullPath = FigPath +full_name
+        FullPath = FigPath + full_name
         self.ChargeInt_Figures_Dict["CAMERA-TEMPERATURE-IMAGE-AVERAGE-2"] = fig2
-        self.ChargeInt_Figures_Names_Dict["CAMERA-TEMPERATURE-IMAGE-AVERAGE-2"] = FullPath
+        self.ChargeInt_Figures_Names_Dict[
+            "CAMERA-TEMPERATURE-IMAGE-AVERAGE-2"
+        ] = FullPath
 
         plt.close()
 
-        return  self.ChargeInt_Figures_Dict, self.ChargeInt_Figures_Names_Dict
-
+        return self.ChargeInt_Figures_Dict, self.ChargeInt_Figures_Names_Dict

--- a/src/nectarchain/dqm/charge_integration.py
+++ b/src/nectarchain/dqm/charge_integration.py
@@ -1,17 +1,24 @@
+from dqm_summary_processor import dqm_summary
+from matplotlib import pyplot as plt
+import numpy as np
+from ctapipe.visualization import CameraDisplay
+from ctapipe.instrument import CameraGeometry
+from traitlets.config.loader import Config
+import ctapipe.instrument.camera.readout
+from ctapipe.image import LocalPeakWindowSum
 
-from dqm_summary_processor import *
 
 class ChargeIntegration_HighLowGain(dqm_summary):
 
     def __init__(self, gaink):
 
-    	self.k = gaink
-    	return None
+        self.k = gaink
+        return None
 
-    def ConfigureForRun(self,path, Chan, Samp, Reader1):
-        #define number of channels and samples
+    def ConfigureForRun(self, path, Chan, Samp, Reader1):
+        # define number of channels and samples
         self.Chan = Chan
-        self.Samp= Samp
+        self.Samp = Samp
 
         self.counter_evt = 0
         self.counter_ped = 0
@@ -19,27 +26,29 @@ class ChargeIntegration_HighLowGain(dqm_summary):
         self.camera = CameraGeometry.from_name("NectarCam-003")
         self.cmap = 'gnuplot2'
 
-        #reader1=EventSource(input_url=path, max_events = 1)
+        # reader1=EventSource(input_url=path, max_events = 1)
         self.subarray = Reader1.subarray
         subarray = Reader1.subarray
-        subarray.tel[0].camera.readout = ctapipe.instrument.camera.readout.CameraReadout.from_name("NectarCam")
-        config = Config({"LocalPeakWindowSum": {"window_shift": 12, "window_width": 12}})
+        subarray.tel[0].camera.readout = \
+            ctapipe.instrument.camera.readout.CameraReadout.from_name("NectarCam")
+        config = Config(
+            {"LocalPeakWindowSum": {"window_shift": 12, "window_width": 12}}
+        )
 
         self.integrator = LocalPeakWindowSum(subarray, config=config)
 
         self.image_all = []
-        self.peakpos_all =  []
+        self.peakpos_all = []
 
         self.image_ped = []
         self.peakpos_ped = []
 
-
     def ProcessEvent(self, evt):
-        #print("test", evt.r0.tel[0].waveform[0])
-        waveform=evt.r0.tel[0].waveform[0]
-        image, peakpos = self.integrator(waveform,0,np.zeros(self.Chan, dtype = int))
+        # print("test", evt.r0.tel[0].waveform[0])
+        waveform = evt.r0.tel[0].waveform[0]
+        image, peakpos = self.integrator(waveform, 0, np.zeros(self.Chan, dtype=int))
 
-        if evt.trigger.event_type.value == 32: #count peds 
+        if evt.trigger.event_type.value == 32:  # count peds
             self.counter_ped += 1
             self.image_ped.append(image)
             self.peakpos_ped.append(peakpos)
@@ -47,257 +56,346 @@ class ChargeIntegration_HighLowGain(dqm_summary):
             self.counter_evt += 1
             self.image_all.append(image)
             self.peakpos_all.append(peakpos)
-    	
 
     def FinishRun(self):
 
-        self.peakpos_all = np.array(self.peakpos_all, dtype = float) 
+        self.peakpos_all = np.array(self.peakpos_all, dtype=float)
         if self.counter_ped > 0:
-            self.peakpos_ped = np.array(self.peakpos_ped, dtype = float)
+            self.peakpos_ped = np.array(self.peakpos_ped, dtype=float)
 
-        #rms, percentile, mean deviation, median, mean, 
-        self.image_all = np.array(self.image_all, dtype = float)       
+        # rms, percentile, mean deviation, median, mean,
+        self.image_all = np.array(self.image_all, dtype=float)
         self.image_all_median = np.median(self.image_all, axis=0)
         self.image_all_average = np.mean(self.image_all, axis=0)
         self.image_all_std = np.std(self.image_all, axis=0)
-        self.image_all_rms = np.sqrt(np.sum(self.image_all**2, axis=0))
+        self.image_all_rms = np.sqrt(np.sum(self.image_all ** 2, axis=0))
 
         if self.counter_ped > 0:
-            self.image_ped = np.array(self.image_ped, dtype = float)
+            self.image_ped = np.array(self.image_ped, dtype=float)
             self.image_ped_median = np.median(self.image_ped, axis=0)
             self.image_ped_average = np.mean(self.image_ped, axis=0)
             self.image_ped_std = np.std(self.image_ped, axis=0)
-            self.image_ped_rms = np.sqrt(np.sum(self.image_ped**2, axis=0))
+            self.image_ped_rms = np.sqrt(np.sum(self.image_ped ** 2, axis=0))
 
-
-    
     def GetResults(self):
 
         self.ChargeInt_Results_Dict = {}
 
-        if (self.k==0):
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-HIGH-GAIN"]  = self.image_all_average
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-HIGH-GAIN"]  = self.image_all_median
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-RMS-HIGH-GAIN"]  = self.image_all_rms
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-STD-HIGH-GAIN"]  = self.image_all_std
+        if (self.k == 0):
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-HIGH-GAIN"
+            ] = self.image_all_average
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-HIGH-GAIN"
+            ] = self.image_all_median
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-RMS-HIGH-GAIN"
+            ] = self.image_all_rms
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-STD-HIGH-GAIN"
+            ] = self.image_all_std
 
             if self.counter_ped > 0:
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-AVERAGE-HIGH-GAIN"]  = self.image_ped_average
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-MEDIAN-HIGH-GAIN"]  = self.image_ped_median
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-RMS-HIGH-GAIN"]  = self.image_ped_rms
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-STD-HIGH-GAIN"]  = self.image_ped_std
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-AVERAGE-HIGH-GAIN"
+                ] = self.image_ped_average
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-MEDIAN-HIGH-GAIN"
+                ] = self.image_ped_median
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-RMS-HIGH-GAIN"
+                ] = self.image_ped_rms
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-STD-HIGH-GAIN"
+                ] = self.image_ped_std
 
-        if (self.k ==1):
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-LOW-GAIN"]  = self.image_all_average 
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-LOW-GAIN"]  = self.image_all_median
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-RMS-LOW-GAIN"]  = self.image_all_rms
-            self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-IMAGE-ALL-STD-LOW-GAIN"]  = self.image_all_std
-            
+        if (self.k == 1):
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-LOW-GAIN"
+            ] = self.image_all_average
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-LOW-GAIN"
+            ] = self.image_all_median
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-RMS-LOW-GAIN"
+            ] = self.image_all_rms
+            self.ChargeInt_Results_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-STD-LOW-GAIN"
+            ] = self.image_all_std
+
             if self.counter_ped > 0:
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-AVERAGE-LOW-GAIN"]  = self.image_ped_average
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-MEDIAN-LOW-GAIN"]  = self.image_ped_median
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-RMS-LOW-GAIN"]  = self.image_ped_rms
-                self.ChargeInt_Results_Dict["CHARGE-INTEGRATION-PED-ALL-STD-LOW-GAIN"]  = self.image_ped_std
-        
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-AVERAGE-LOW-GAIN"
+                ] = self.image_ped_average
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-MEDIAN-LOW-GAIN"
+                ] = self.image_ped_median
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-RMS-LOW-GAIN"
+                ] = self.image_ped_rms
+                self.ChargeInt_Results_Dict[
+                    "CHARGE-INTEGRATION-PED-ALL-STD-LOW-GAIN"
+                ] = self.image_ped_std
 
         return self.ChargeInt_Results_Dict
 
-
-    def PlotResults(self,name,FigPath):
+    def PlotResults(self, name, FigPath):
         self.ChargeInt_Figures_Dict = {}
         self.ChargeInt_Figures_Names_Dict = {}
 
-
-        titles = ['All', 'Pedestals']
-        if (self.k==0):
+        # titles = ['All', 'Pedestals']
+        if (self.k == 0):
             gain_c = 'High'
-        if (self.k ==1):
+        if (self.k == 1):
             gain_c = 'Low'
 
-
-        #Charge integration MEAN plot
+        # Charge integration MEAN plot
         if self.counter_evt > 0:
             fig1, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
-            #disp = CameraDisplay(self.subarray.tels[0].camera)
+            # disp = CameraDisplay(self.subarray.tels[0].camera)
             disp.image = self.image_all_average
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
 
-            plt.title("Charge Integration Mean %s Gain (ALL)" %gain_c)
+            plt.title("Charge Integration Mean %s Gain (ALL)" % gain_c)
 
-            full_name = name + '_ChargeInt_Mean_%sGain_All.png' %gain_c 
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-%s-GAIN" %gain_c] = fig1
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-%s-GAIN" %gain_c] = FullPath
+            full_name = name + '_ChargeInt_Mean_%sGain_All.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-%s-GAIN" % gain_c
+            ] = fig1
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-AVERAGE-%s-GAIN" % gain_c
+            ] = FullPath
 
             plt.close()
-
 
         if self.counter_ped > 0:
             fig2, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_ped_average
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
 
-            plt.title("Charge Integration Mean %s Gain (PED)" %gain_c)
+            plt.title("Charge Integration Mean %s Gain (PED)" % gain_c)
 
-            full_name = name + '_ChargeInt_Mean_%sGain_Ped.png' %gain_c 
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-PED-AVERAGE-%s-GAIN" %gain_c] = fig2
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-PED-AVERAGE-%s-GAIN" %gain_c] = FullPath
+            full_name = name + '_ChargeInt_Mean_%sGain_Ped.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-AVERAGE-%s-GAIN" % gain_c
+            ] = fig2
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-AVERAGE-%s-GAIN" % gain_c
+            ] = FullPath
 
             plt.close()
 
-
-        #Charge integration MEDIAN plot
+        # Charge integration MEDIAN plot
         if self.counter_evt > 0:
             fig3, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_all_median
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
-    
-            plt.title("Charge Integration Median %s Gain (ALL)" %gain_c)
-    
-            full_name = name + '_ChargeInt_Median_%sGain_All.png' %gain_c 
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-%s-GAIN" %gain_c] = fig3
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-%s-GAIN" %gain_c] = FullPath
-    
-            plt.close()
 
+            plt.title("Charge Integration Median %s Gain (ALL)" % gain_c)
+
+            full_name = name + '_ChargeInt_Median_%sGain_All.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-%s-GAIN" % gain_c
+            ] = fig3
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-MEDIAN-%s-GAIN" % gain_c
+            ] = FullPath
+
+            plt.close()
 
         if self.counter_ped > 0:
             fig4, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_ped_median
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
 
-            plt.title("Charge Integration Median %s Gain (PED)" %gain_c)
-            
-            full_name = name + '_ChargeInt_Median_%sGain_Ped.png' %gain_c
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-PED-MEDIAN-%s-GAIN" %gain_c] = fig4
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-PED-MEDIAN-%s-GAIN" %gain_c] = FullPath
+            plt.title("Charge Integration Median %s Gain (PED)" % gain_c)
+
+            full_name = name + '_ChargeInt_Median_%sGain_Ped.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-MEDIAN-%s-GAIN" % gain_c
+            ] = fig4
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-MEDIAN-%s-GAIN" % gain_c
+            ] = FullPath
 
             plt.close()
 
-
-        #Charge integration STD plot
+        # Charge integration STD plot
         if self.counter_evt > 0:
             fig5, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_all_std
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
-    
-            plt.title("Charge Integration STD %s Gain (ALL)" %gain_c)
-                
-            full_name = name + '_ChargeInt_Std_%sGain_All.png' %gain_c
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-ALL-STD-%s-GAIN" %gain_c] = fig5
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-ALL-STD-%s-GAIN" %gain_c] = FullPath
-    
+
+            plt.title("Charge Integration STD %s Gain (ALL)" % gain_c)
+
+            full_name = name + '_ChargeInt_Std_%sGain_All.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-STD-%s-GAIN" % gain_c
+            ] = fig5
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-STD-%s-GAIN" % gain_c
+            ] = FullPath
+
             plt.close()
-        
+
         if self.counter_ped > 0:
             fig6, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_ped_std
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
 
-            plt.title("Charge Integration STD %s Gain (PED)" %gain_c)
-            
-            full_name = name + '_ChargeInt_Std_%sGain_Ped.png' %gain_c
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-PED-STD-%s-GAIN" %gain_c] = fig6
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-PED-STD-%s-GAIN" %gain_c] = FullPath
+            plt.title("Charge Integration STD %s Gain (PED)" % gain_c)
+
+            full_name = name + '_ChargeInt_Std_%sGain_Ped.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-STD-%s-GAIN" % gain_c
+            ] = fig6
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-STD-%s-GAIN" % gain_c
+            ] = FullPath
 
             plt.close()
 
-
-        
-        #Charge integration RMS plot
+        # Charge integration RMS plot
         if self.counter_evt > 0:
             fig7, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_all_rms
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
-    
-            plt.title("Charge Integration RMS %s Gain (ALL)" %gain_c)
-                
-            full_name = name + '_ChargeInt_Rms_%sGain_All.png' %gain_c
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-ALL-RMS-%s-GAIN" %gain_c] = fig7
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-ALL-RMS-%s-GAIN" %gain_c] = FullPath
-    
+
+            plt.title("Charge Integration RMS %s Gain (ALL)" % gain_c)
+
+            full_name = name + '_ChargeInt_Rms_%sGain_All.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-RMS-%s-GAIN" % gain_c
+            ] = fig7
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-ALL-RMS-%s-GAIN" % gain_c
+            ] = FullPath
+
             plt.close()
-    
+
         if self.counter_ped > 0:
             fig8, disp = plt.subplots()
             disp = CameraDisplay(self.camera)
             disp.image = self.image_ped_rms
             disp.cmap = plt.cm.coolwarm
-            disp.axes.text(2, -0.8, f'{gain_c} gain integrated charge (DC)', fontsize=12,rotation=90)
+            disp.axes.text(
+                2, -0.8, f'{gain_c} gain integrated charge (DC)',
+                fontsize=12, rotation=90
+            )
             disp.add_colorbar()
 
-            plt.title("Charge Integration RMS %s Gain (PED)" %gain_c)
-            
-            full_name = name + '_ChargeInt_Rms_%sGain_Ped.png' %gain_c
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-IMAGE-PED-RMS-%s-GAIN" %gain_c] = fig8
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-IMAGE-PED-RMS-%s-GAIN" %gain_c] = FullPath
+            plt.title("Charge Integration RMS %s Gain (PED)" % gain_c)
+
+            full_name = name + '_ChargeInt_Rms_%sGain_Ped.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-RMS-%s-GAIN" % gain_c
+            ] = fig8
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-IMAGE-PED-RMS-%s-GAIN" % gain_c
+            ] = FullPath
 
             plt.close()
 
-
-        #Charge integration SPECTRUM
+        # Charge integration SPECTRUM
         if self.counter_evt > 0:
             fig9, disp = plt.subplots()
             for i in range(self.Chan):
-                plt.hist(self.image_all[:,i],100, fill=False, density = True, stacked=True, linewidth=1, log = True, alpha = 0.01)
-            plt.hist(np.mean(self.image_all, axis=1),100, color = 'r', linewidth=1, log = True, alpha = 1, label = 'Camera average')
+                plt.hist(self.image_all[:, i], 100, fill=False,
+                         density=True, stacked=True, linewidth=1,
+                         log=True, alpha=0.01)
+            plt.hist(np.mean(self.image_all, axis=1), 100, color='r',
+                     linewidth=1, log=True, alpha=1,
+                     label='Camera average'
+                     )
             plt.legend()
             plt.xlabel("Charge (DC)")
-            plt.title("Charge spectrum %s gain (ALL)" %gain_c)
-                
-            full_name = name + '_Charge_Spectrum_%sGain_All.png' %gain_c 
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-SPECTRUM-ALL-%s-GAIN" %gain_c] = fig9
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-SPECTRUM-ALL-%s-GAIN" %gain_c] = FullPath
-    
+            plt.title("Charge spectrum %s gain (ALL)" % gain_c)
+
+            full_name = name + '_Charge_Spectrum_%sGain_All.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-SPECTRUM-ALL-%s-GAIN" % gain_c
+            ] = fig9
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-SPECTRUM-ALL-%s-GAIN" % gain_c
+            ] = FullPath
+
             plt.close()
 
         if self.counter_ped > 0:
             fig10, disp = plt.subplots()
             for i in range(self.Chan):
-                plt.hist(self.image_ped[:,i],100, fill=False, density = True, stacked=True, linewidth=1, log = True, alpha = 0.01)
-            plt.hist(np.mean(self.image_ped, axis=1),100, color = 'r', linewidth=1, log = True, alpha = 1, label = 'Camera average')
+                plt.hist(self.image_ped[:, i], 100, fill=False,
+                         density=True, stacked=True, linewidth=1,
+                         log=True, alpha=0.01
+                         )
+            plt.hist(np.mean(self.image_ped, axis=1),
+                     100, color='r', linewidth=1, log=True,
+                     alpha=1, label='Camera average'
+                     )
             plt.legend()
             plt.xlabel("Charge (DC)")
-            plt.title("Charge spectrum %s gain (PED)" %gain_c)
-                
-            full_name = name + '_Charge_Spectrum_%sGain_Ped.png' %gain_c  
-            FullPath = FigPath +full_name
-            self.ChargeInt_Figures_Dict["CHARGE-INTEGRATION-SPECTRUM-PED-%s-GAIN" %gain_c] = fig10
-            self.ChargeInt_Figures_Names_Dict["CHARGE-INTEGRATION-SPECTRUM-PED-%s-GAIN" %gain_c] = FullPath
+            plt.title("Charge spectrum %s gain (PED)" % gain_c)
+
+            full_name = name + '_Charge_Spectrum_%sGain_Ped.png' % gain_c
+            FullPath = FigPath + full_name
+            self.ChargeInt_Figures_Dict[
+                "CHARGE-INTEGRATION-SPECTRUM-PED-%s-GAIN" % gain_c
+            ] = fig10
+            self.ChargeInt_Figures_Names_Dict[
+                "CHARGE-INTEGRATION-SPECTRUM-PED-%s-GAIN" % gain_c
+            ] = FullPath
 
             plt.close()
 
-
-        return  self.ChargeInt_Figures_Dict, self.ChargeInt_Figures_Names_Dict
-
-
-
+        return self.ChargeInt_Figures_Dict, self.ChargeInt_Figures_Names_Dict

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -1,33 +1,5 @@
-
 import pickle
 
-import os
-import sys
-
-
-#from ctapipe.io import event_source
-import sys
- 
-from matplotlib import pyplot as plt
-import numpy as np
-from scipy.stats import norm
-from traitlets.config.loader import Config 
-from astropy.io import fits
-
-# ctapipe modules
-from ctapipe import utils
-from ctapipe.visualization import CameraDisplay
-#from ctapipe.plotting.camera import CameraPlotter
-from ctapipe.image.extractor import *
-from ctapipe.io import EventSeeker 
-from ctapipe.instrument import CameraGeometry
-
-from ctapipe.io.hdf5tableio import HDF5TableWriter, HDF5TableReader
-
-from ctapipe.io import EventSource
-import ctapipe.instrument.camera.readout
-
-from astropy import time as astropytime
 
 class dqm_summary:
     def __init__(self):
@@ -36,7 +8,7 @@ class dqm_summary:
     def DefineForRun(self, reader1):
         for i, evt1 in enumerate(reader1):
             self.FirstReader = reader1
-            self.Samp= len(evt1.r0.tel[0].waveform[0][0])
+            self.Samp = len(evt1.r0.tel[0].waveform[0][0])
             self.Chan = len(evt1.r0.tel[0].waveform[0])
 
         return self.Chan, self.Samp
@@ -53,13 +25,12 @@ class dqm_summary:
     def GetResults(self):
         print('Processor 4')
 
-    def PlotResults(self, name,FigPath,k, M, M_ped, Mean_M_overChan, Mean_M_ped_overChan):
+    def PlotResults(self, name, FigPath, k, M, M_ped, Mean_M_overChan,
+                    Mean_M_ped_overChan):
         print('Processor 5')
 
-
-    def WriteAllResults(self,path, DICT):
+    def WriteAllResults(self, path, DICT):
         PickleName = path + '_Results.pickle'
         with open(PickleName, 'wb') as handle:
-            pickle.dump(DICT, handle, protocol=pickle.HIGHEST_PROTOCOL) 
+            pickle.dump(DICT, handle, protocol=pickle.HIGHEST_PROTOCOL)
         return None
-

--- a/src/nectarchain/dqm/mean_camera_display.py
+++ b/src/nectarchain/dqm/mean_camera_display.py
@@ -1,18 +1,21 @@
-from dqm_summary_processor import *
+from dqm_summary_processor import dqm_summary
+from matplotlib import pyplot as plt
+from ctapipe.visualization import CameraDisplay
+from ctapipe.instrument import CameraGeometry
+import numpy as np
+
 
 class MeanCameraDisplay_HighLowGain(dqm_summary):
 
-
     def __init__(self, gaink):
-        
+
         self.k = gaink
         return None
 
-    def ConfigureForRun(self,path, Chan, Samp, Reader1):
-        #define number of channels and samples
+    def ConfigureForRun(self, path, Chan, Samp, Reader1):
+        # define number of channels and samples
         self.Chan = Chan
-        self.Samp= Samp
-
+        self.Samp = Samp
 
         self.CameraAverage = np.zeros((self.Chan))
         self.CameraAverage_ped = np.zeros((self.Chan))
@@ -25,98 +28,118 @@ class MeanCameraDisplay_HighLowGain(dqm_summary):
         self.cmap = 'gnuplot2'
         self.cmap2 = 'gnuplot2'
 
-
-
     def ProcessEvent(self, evt):
-        if evt.trigger.event_type.value == 32: #count peds 
+        if evt.trigger.event_type.value == 32:  # count peds
             self.counter_ped += 1
         else:
             self.counter_evt += 1
 
-        if evt.trigger.event_type.value == 32: #only peds now
-            self.CameraAverage_ped += evt.r0.tel[0].waveform[self.k].sum(axis=1) # fill channels one by one and sum them for peds only
+        if evt.trigger.event_type.value == 32:  # only peds now
+            self.CameraAverage_ped += evt.r0.tel[0].waveform[self.k].sum(
+                axis=1)  # fill channels one by one and sum them for peds only
         else:
-            self.CameraAverage += evt.r0.tel[0].waveform[self.k].sum(axis=1) # fill channels one by one and sum them
+            self.CameraAverage += evt.r0.tel[0].waveform[self.k].sum(
+                axis=1)  # fill channels one by one and sum them
         return None
 
     def FinishRun(self):
 
-        self.CameraAverage_overEvents = self.CameraAverage/self.counter_evt
-        self.CameraAverage_overEvents_overSamp = self.CameraAverage_overEvents/self.Samp
+        self.CameraAverage_overEvents = self.CameraAverage / self.counter_evt
+        self.CameraAverage_overEvents_overSamp = \
+            self.CameraAverage_overEvents / self.Samp
 
         if self.counter_ped > 0:
-            self.CameraAverage_ped_overEvents = self.CameraAverage_ped/self.counter_ped
-            self.CameraAverage_ped_overEvents_overSamp = self.CameraAverage_ped_overEvents/self.Samp
+            self.CameraAverage_ped_overEvents = \
+                self.CameraAverage_ped / self.counter_ped
+            self.CameraAverage_ped_overEvents_overSamp = \
+                self.CameraAverage_ped_overEvents / self.Samp
 
     def GetResults(self):
-        #INITIATE DICT
+        # INITIATE DICT
         self.MeanCameraDisplay_Results_Dict = {}
 
-        #ASSIGN RESUTLS TO DICT
-        if (self.k==0):
-            #self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-OverEVENTS-HIGH-GAIN"]  = self.CameraAverage_overEvents
-            self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-PHY-OverEVENTS-OverSamp-HIGH-GAIN"] = self.CameraAverage_overEvents_overSamp
-            
+        # ASSIGN RESUTLS TO DICT
+        if (self.k == 0):
+            # self.MeanCameraDisplay_Results_Dict[
+            # "CAMERA-AVERAGE-OverEVENTS-HIGH-GAIN"
+            # ]  = self.CameraAverage_overEvents
+            self.MeanCameraDisplay_Results_Dict[
+                "CAMERA-AVERAGE-PHY-OverEVENTS-OverSamp-HIGH-GAIN"
+            ] = self.CameraAverage_overEvents_overSamp
 
             if self.counter_ped > 0:
-                #self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-PED-OverEVENTS-HIGH-GAIN"]= self.CameraAverage_ped_overEvents
-                self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-PED-OverEVENTS-OverSamp-HIGH-GAIN"]= self.CameraAverage_ped_overEvents_overSamp
+                # self.MeanCameraDisplay_Results_Dict[
+                # "CAMERA-AVERAGE-PED-OverEVENTS-HIGH-GAIN"
+                # ]= self.CameraAverage_ped_overEvents
+                self.MeanCameraDisplay_Results_Dict[
+                    "CAMERA-AVERAGE-PED-OverEVENTS-OverSamp-HIGH-GAIN"
+                ] = self.CameraAverage_ped_overEvents_overSamp
 
-
-        if (self.k ==1):
-            #self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-OverEVENTS-LOW-GAIN"]  = self.CameraAverage_overEvents
-            self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-PHY-OverEVENTS-OverSamp-LOW-GAIN"] = self.CameraAverage_overEvents_overSamp
+        if (self.k == 1):
+            # self.MeanCameraDisplay_Results_Dict[
+            # "CAMERA-AVERAGE-OverEVENTS-LOW-GAIN"
+            # ]  = self.CameraAverage_overEvents
+            self.MeanCameraDisplay_Results_Dict[
+                "CAMERA-AVERAGE-PHY-OverEVENTS-OverSamp-LOW-GAIN"
+            ] = self.CameraAverage_overEvents_overSamp
 
             if self.counter_ped > 0:
-                #self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-PED-OverEVENTS-LOW-GAIN"]= self.CameraAverage_ped_overEvents
-                self.MeanCameraDisplay_Results_Dict["CAMERA-AVERAGE-PED-OverEVENTS-OverSamp-LOW-GAIN"]= self.CameraAverage_ped_overEvents_overSamp
+                # self.MeanCameraDisplay_Results_Dict[
+                # "CAMERA-AVERAGE-PED-OverEVENTS-LOW-GAIN"
+                # ]= self.CameraAverage_ped_overEvents
+                self.MeanCameraDisplay_Results_Dict[
+                    "CAMERA-AVERAGE-PED-OverEVENTS-OverSamp-LOW-GAIN"
+                ] = self.CameraAverage_ped_overEvents_overSamp
 
         return self.MeanCameraDisplay_Results_Dict
 
-
-    def PlotResults(self,name,FigPath):
+    def PlotResults(self, name, FigPath):
         self.MeanCameraDisplay_Figures_Dict = {}
         self.MeanCameraDisplay_Figures_Names_Dict = {}
-        
-        titles = ['All', 'Pedestals']
-        if (self.k==0):
+
+        # titles = ['All', 'Pedestals']
+        if (self.k == 0):
             gain_c = 'High'
-        if (self.k ==1):
+        if (self.k == 1):
             gain_c = 'Low'
 
         if self.counter_evt > 0:
             fig1, self.disp1 = plt.subplots()
-            self.disp1 = CameraDisplay(geometry=self.camera, image=self.CameraAverage_overEvents_overSamp, cmap=self.cmap)
+            self.disp1 = CameraDisplay(geometry=self.camera,
+                                       image=self.CameraAverage_overEvents_overSamp,
+                                       cmap=self.cmap)
             self.disp1.cmap = self.cmap
             self.disp1.cmap = plt.cm.coolwarm
             self.disp1.add_colorbar()
             self.disp1.axes.text(2.0, 0, 'Charge (DC)', rotation=90)
-            plt.title("Camera average %s gain (ALL)" %gain_c)
-            
-            self.MeanCameraDisplay_Figures_Dict["CAMERA-AVERAGE-PHY-DISPLAY-%s-GAIN" %gain_c] = fig1
-            full_name = name + '_Camera_Mean_%sGain.png' %gain_c 
-            FullPath = FigPath +full_name
-            self.MeanCameraDisplay_Figures_Names_Dict["CAMERA-AVERAGE-PHY-DISPLAY-%s-GAIN" %gain_c] = FullPath
-            plt.close()
+            plt.title("Camera average %s gain (ALL)" % gain_c)
 
+            self.MeanCameraDisplay_Figures_Dict[
+                "CAMERA-AVERAGE-PHY-DISPLAY-%s-GAIN" % gain_c] = fig1
+            full_name = name + '_Camera_Mean_%sGain.png' % gain_c
+            FullPath = FigPath + full_name
+            self.MeanCameraDisplay_Figures_Names_Dict[
+                "CAMERA-AVERAGE-PHY-DISPLAY-%s-GAIN" % gain_c] = FullPath
+            plt.close()
 
         if self.counter_ped > 0:
             fig2, self.disp2 = plt.subplots()
-            self.disp2 = CameraDisplay(geometry=self.camera2, image=self.CameraAverage_ped_overEvents_overSamp, cmap=self.cmap2)
+            self.disp2 = CameraDisplay(geometry=self.camera2,
+                                       image=self.CameraAverage_ped_overEvents_overSamp,
+                                       cmap=self.cmap2)
             self.disp2.cmap = self.cmap2
             self.disp2.cmap = plt.cm.coolwarm
             self.disp2.add_colorbar()
             self.disp2.axes.text(2.0, 0, 'Charge (DC)', rotation=90)
-            plt.title("Camera average %s gain (PED)" %gain_c)
+            plt.title("Camera average %s gain (PED)" % gain_c)
 
-            self.MeanCameraDisplay_Figures_Dict["CAMERA-AVERAGE-PED-DISPLAY-%s-GAIN" %gain_c] = fig2
-            full_name = name + '_Pedestal_Mean_%sGain.png' %gain_c
-            FullPath = FigPath +full_name
-            self.MeanCameraDisplay_Figures_Names_Dict["CAMERA-AVERAGE-PED-DISPLAY-%s-GAIN" %gain_c] = FullPath
+            self.MeanCameraDisplay_Figures_Dict[
+                "CAMERA-AVERAGE-PED-DISPLAY-%s-GAIN" % gain_c] = fig2
+            full_name = name + '_Pedestal_Mean_%sGain.png' % gain_c
+            FullPath = FigPath + full_name
+            self.MeanCameraDisplay_Figures_Names_Dict[
+                "CAMERA-AVERAGE-PED-DISPLAY-%s-GAIN" % gain_c] = FullPath
             plt.close()
-            
-        return  self.MeanCameraDisplay_Figures_Dict, self.MeanCameraDisplay_Figures_Names_Dict
 
-
-
-
+        return self.MeanCameraDisplay_Figures_Dict, \
+            self.MeanCameraDisplay_Figures_Names_Dict

--- a/src/nectarchain/dqm/mean_waveforms.py
+++ b/src/nectarchain/dqm/mean_waveforms.py
@@ -1,5 +1,6 @@
-
-from dqm_summary_processor import *
+from dqm_summary_processor import dqm_summary
+from matplotlib import pyplot as plt
+import numpy as np
 
 
 class MeanWaveForms_HighLowGain(dqm_summary):
@@ -9,90 +10,89 @@ class MeanWaveForms_HighLowGain(dqm_summary):
         self.k = gaink
         return None
 
-    def ConfigureForRun(self,path, Chan, Samp, Reader1):
-        #define number of channels and samples
+    def ConfigureForRun(self, path, Chan, Samp, Reader1):
+        # define number of channels and samples
         self.Chan = Chan
-        self.Samp= Samp
+        self.Samp = Samp
 
-        #redefine everything
-        self.Mwf = np.zeros((self.Chan,self.Samp))
-        self.Mwf_ped = np.zeros((self.Chan,self.Samp))
+        # redefine everything
+        self.Mwf = np.zeros((self.Chan, self.Samp))
+        self.Mwf_ped = np.zeros((self.Chan, self.Samp))
         self.counter_evt = 0
         self.counter_ped = 0
 
-        self.Mwf_average = np.zeros((self.Chan,self.Samp))
-        self.Mwf_ped_average = np.zeros((self.Chan,self.Samp))
+        self.Mwf_average = np.zeros((self.Chan, self.Samp))
+        self.Mwf_ped_average = np.zeros((self.Chan, self.Samp))
         self.Mwf_Mean_overChan = []
         self.Mwf_ped_Mean_overChan = []
 
-
-        self.wf_list_plot = list(range(1, self.Samp+1))#used for plotting later on
-
-        
+        self.wf_list_plot = list(range(1, self.Samp + 1))  # used for plotting later on
 
         return None
 
-
     def ProcessEvent(self, evt):
-        if evt.trigger.event_type.value == 32: #count peds 
+        if evt.trigger.event_type.value == 32:  # count peds
             self.counter_ped += 1
         else:
             self.counter_evt += 1
-            
-        for ichan in range(self.Chan): #loop over channels # 1855 should be redefined as a variable
-            if evt.trigger.event_type.value == 32: #only peds now
-                self.Mwf_ped[ichan,:] += evt.r0.tel[0].waveform[self.k][ichan] # fill channels one by one and sum them for peds only
-            else:
-                self.Mwf[ichan,:] += evt.r0.tel[0].waveform[self.k][ichan] # fill channels one by one and sum them
-        return None
 
+        for ichan in range(self.Chan):
+            # loop over channels, 1855 should be redefined as a variable
+            if evt.trigger.event_type.value == 32:  # only peds now
+                self.Mwf_ped[ichan, :] += evt.r0.tel[0].waveform[self.k][
+                    ichan]  # fill channels one by one and sum them for peds only
+            else:
+                self.Mwf[ichan, :] += evt.r0.tel[0].waveform[self.k][
+                    ichan]  # fill channels one by one and sum them
+        return None
 
     def FinishRun(self):
-        if (self.k==0):
-            gain_c = 'High'
-        if (self.k ==1):
-            gain_c = 'Low'
+        # if (self.k == 0):
+        #   gain_c = 'High'
+        # if (self.k == 1):
+        #    gain_c = 'Low'
 
+        self.Mwf_average = self.Mwf / self.counter_evt  # get average
+        # get average over channels
+        self.Mwf_Mean_overChan = np.mean(self.Mwf_average, axis=0)
 
-        self.Mwf_average = self.Mwf/self.counter_evt #get average
-        #get average over channels 
-        self.Mwf_Mean_overChan = np.mean(self.Mwf_average,axis=0)
-        
         if self.counter_ped > 0:
-            self.Mwf_ped_average = self.Mwf_ped/self.counter_ped #get average pedestals
-            self.Mwf_ped_Mean_overChan = np.mean(self.Mwf_ped_average,axis=0)
+            # get average pedestals
+            self.Mwf_ped_average = self.Mwf_ped / self.counter_ped
+            self.Mwf_ped_Mean_overChan = np.mean(self.Mwf_ped_average, axis=0)
 
         return None
-
 
     def GetResults(self):
 
-        #INITIATE DICT
+        # INITIATE DICT
         self.MeanWaveForms_Results_Dict = {}
 
-        #ASSIGN RESUTLS TO DICT
-        if (self.k==0):
-            self.MeanWaveForms_Results_Dict["WF-PHY-AVERAGE-HIGH-GAIN"]  = self.Mwf_average
-            self.MeanWaveForms_Results_Dict["WF-PHY-AVERAGE-CHAN-HIGH-GAIN"]  = self.Mwf_Mean_overChan
+        # ASSIGN RESUTLS TO DICT
+        if (self.k == 0):
+            self.MeanWaveForms_Results_Dict[
+                "WF-PHY-AVERAGE-HIGH-GAIN"] = self.Mwf_average
+            self.MeanWaveForms_Results_Dict[
+                "WF-PHY-AVERAGE-CHAN-HIGH-GAIN"] = self.Mwf_Mean_overChan
             if self.counter_ped > 0:
-                self.MeanWaveForms_Results_Dict["WF-PED-AVERAGE-HIGH-GAIN"] = self.Mwf_ped_average
-                self.MeanWaveForms_Results_Dict["WF-AVERAGE-PED-CHAN-HIGH-GAIN"]  = self.Mwf_ped_Mean_overChan
+                self.MeanWaveForms_Results_Dict[
+                    "WF-PED-AVERAGE-HIGH-GAIN"] = self.Mwf_ped_average
+                self.MeanWaveForms_Results_Dict[
+                    "WF-AVERAGE-PED-CHAN-HIGH-GAIN"] = self.Mwf_ped_Mean_overChan
 
-
-
-        if (self.k ==1):
-            self.MeanWaveForms_Results_Dict["WF-AVERAGE-LOW-GAIN"]  = self.Mwf_average
-            self.MeanWaveForms_Results_Dict["WF-AVERAGE-CHAN-LOW-GAIN"]  = self.Mwf_Mean_overChan
+        if (self.k == 1):
+            self.MeanWaveForms_Results_Dict["WF-AVERAGE-LOW-GAIN"] = self.Mwf_average
+            self.MeanWaveForms_Results_Dict[
+                "WF-AVERAGE-CHAN-LOW-GAIN"] = self.Mwf_Mean_overChan
             if self.counter_ped > 0:
-                self.MeanWaveForms_Results_Dict["WF-PHY-PED-AVERAGE-LOW-GAIN"] = self.Mwf_ped_average
-                self.MeanWaveForms_Results_Dict["WF-PHY-AVERAGE-PED-CHAN-LOW-GAIN"]  = self.Mwf_ped_Mean_overChan
-                
-
+                self.MeanWaveForms_Results_Dict[
+                    "WF-PHY-PED-AVERAGE-LOW-GAIN"] = self.Mwf_ped_average
+                self.MeanWaveForms_Results_Dict[
+                    "WF-PHY-AVERAGE-PED-CHAN-LOW-GAIN"] = self.Mwf_ped_Mean_overChan
 
         return self.MeanWaveForms_Results_Dict
 
-
-    def PlotResults(self,name,FigPath):
+    def PlotResults(self, name, FigPath):
         self.MeanWaveForms_Figures_Dict = {}
         self.MeanWaveForms_Figures_Names_Dict = {}
 
@@ -100,70 +100,77 @@ class MeanWaveForms_HighLowGain(dqm_summary):
 
         counter_fig = 0
         colors = ['blue', 'red']
-        colors2 = ['cyan', 'orange']
+        # colors2 = ['cyan', 'orange']
         titles = ['Physical', 'Pedestals']
 
-        Mean_plot_array = [self.Mwf_Mean_overChan, self.Mwf_ped_Mean_overChan]
+        # Mean_plot_array = [self.Mwf_Mean_overChan, self.Mwf_ped_Mean_overChan]
 
-        #Set characters of gain: high or lo
-        if (self.k==0):
+        # Set characters of gain: high or lo
+        if (self.k == 0):
             gain_c = 'High'
-        if (self.k ==1):
+        if (self.k == 1):
             gain_c = 'Low'
 
         full_fig, full_ax = plt.subplots()
         if self.counter_ped > 0:
             array_plot = [self.Mwf_average, self.Mwf_ped_average]
-        else: 
+        else:
             array_plot = [self.Mwf_average]
 
-            
         for x in array_plot:
 
             part_fig, part_ax = plt.subplots()
 
             for ichan in range(self.Chan):
-                full_ax.plot(wf_list ,x[ichan,:], color = colors[counter_fig], alpha = 0.005, linewidth=1)
-                part_ax.plot(wf_list ,x[ichan,:], color = colors[counter_fig], alpha = 0.005, linewidth=1)
+                full_ax.plot(wf_list, x[ichan, :], color=colors[counter_fig],
+                             alpha=0.005, linewidth=1)
+                part_ax.plot(wf_list, x[ichan, :], color=colors[counter_fig],
+                             alpha=0.005, linewidth=1)
 
-            Mean_plot = Mean_plot_array[counter_fig]
+            # Mean_plot = Mean_plot_array[counter_fig]
 
-            full_ax_return = full_ax.plot(wf_list, Mean_plot, color = colors2[counter_fig], alpha = 1, linewidth=3, label = 'Mean ' + titles[counter_fig])
-            part_ax_return = part_ax.plot(wf_list, Mean_plot, color = colors2[counter_fig], alpha = 1, linewidth=3, label = 'Mean ' + titles[counter_fig])
-            part_ax.set_title('Mean Waveforms %s (%s Gain)' %(titles[counter_fig], gain_c))
+            # full_ax_return = full_ax.plot(wf_list, Mean_plot,
+            #                              color=colors2[counter_fig], alpha=1,
+            #                              linewidth=3,
+            #                              label='Mean ' + titles[counter_fig])
+            # part_ax_return = part_ax.plot(wf_list, Mean_plot,
+            #                              color=colors2[counter_fig], alpha=1,
+            #                              linewidth=3,
+            #                              label='Mean ' + titles[counter_fig])
+            part_ax.set_title(
+                'Mean Waveforms %s (%s Gain)' % (titles[counter_fig], gain_c))
             part_ax.set_xlabel('Samples')
             part_ax.set_ylabel('Amplitude (DC)')
             part_ax.legend()
             part_ax.grid()
 
-            part_name = name + '_MeanWaveforms_%s_%sGain.png' %(titles[counter_fig], gain_c)
+            part_name = name + '_MeanWaveforms_%s_%sGain.png' % (
+                titles[counter_fig], gain_c
+            )
             PartPath = FigPath + part_name
-            
-            self.MeanWaveForms_Figures_Dict["FIGURE-WF-%s-%s-GAIN" %(titles[counter_fig], gain_c)]= part_fig
-            self.MeanWaveForms_Figures_Names_Dict["FIGURE-WF-%s-%s-GAIN" %(titles[counter_fig], gain_c)]= PartPath
+
+            self.MeanWaveForms_Figures_Dict[
+                "FIGURE-WF-%s-%s-GAIN" % (titles[counter_fig], gain_c)] = part_fig
+            self.MeanWaveForms_Figures_Names_Dict[
+                "FIGURE-WF-%s-%s-GAIN" % (titles[counter_fig], gain_c)] = PartPath
 
             plt.close()
 
+            counter_fig += 1
 
-            counter_fig +=1
-        
         full_ax.set_title('Mean Waveforms Combined Plot (%s Gain)' % gain_c)
         full_ax.set_xlabel('Samples')
         full_ax.set_ylabel('Amplitude (DC)')
         full_ax.legend()
         full_ax.grid()
 
-        full_name = name + '_MeanWaveforms_CombinedPlot_%sGain.png' %gain_c
-        FullPath = FigPath +full_name
-        self.MeanWaveForms_Figures_Dict["FIGURE-WF-COMBINED-%s-GAIN" % gain_c] = full_fig
-        self.MeanWaveForms_Figures_Names_Dict["FIGURE-WF-COMBINED-%s-GAIN" % gain_c]= FullPath
+        full_name = name + '_MeanWaveforms_CombinedPlot_%sGain.png' % gain_c
+        FullPath = FigPath + full_name
+        self.MeanWaveForms_Figures_Dict[
+            "FIGURE-WF-COMBINED-%s-GAIN" % gain_c] = full_fig
+        self.MeanWaveForms_Figures_Names_Dict[
+            "FIGURE-WF-COMBINED-%s-GAIN" % gain_c] = FullPath
 
         plt.close()
 
-
-        return  self.MeanWaveForms_Figures_Dict, self.MeanWaveForms_Figures_Names_Dict
-
-
-
-
-
+        return self.MeanWaveForms_Figures_Dict, self.MeanWaveForms_Figures_Names_Dict

--- a/src/nectarchain/dqm/start_calib.py
+++ b/src/nectarchain/dqm/start_calib.py
@@ -3,12 +3,11 @@ import sys
 
 from matplotlib import pyplot as plt
 
-#from multiprocessing import Process
+# from multiprocessing import Process
 
 import time
 
 from ctapipe.io import EventSource, EventSeeker
-
 
 from mean_waveforms import MeanWaveForms_HighLowGain
 from mean_camera_display import MeanCameraDisplay_HighLowGain
@@ -16,25 +15,26 @@ from charge_integration import ChargeIntegration_HighLowGain
 from trigger_statistics import TriggerStatistics
 from camera_monitoring import CameraMonitoring
 
-
 print(sys.argv)
-path = sys.argv[1] # path of the Run file: ./NectarCAM.Run2720.0000.fits.fz
+path = sys.argv[1]  # path of the Run file: ./NectarCAM.Run2720.0000.fits.fz
 
 NectarPath = str(os.environ['NECTARDIR'])
 
+
 def GetName(RunFile):
     name = RunFile.split('/')[-1]
-    name = name.split('.')[0] + '_' + name.split('.')[1]# + '_' +name.split('.')[2]
+    name = name.split('.')[0] + '_' + name.split('.')[1]  # + '_' +name.split('.')[2]
     print(name)
     return name
 
+
 def CreateFigFolder(name, type):
-    if(type == 0):
+    if (type == 0):
         folder = 'Plots'
 
     ParentFolderName = name.split('_')[0] + '_' + name.split('_')[1]
-    ChildrenFolderName = './' + ParentFolderName +'/' + name + '_calib'
-    FolderPath = NectarPath + 'output/%s/%s/' %(ChildrenFolderName, folder)
+    ChildrenFolderName = './' + ParentFolderName + '/' + name + '_calib'
+    FolderPath = NectarPath + 'output/%s/%s/' % (ChildrenFolderName, folder)
 
     if not os.path.exists(FolderPath):
         os.makedirs(FolderPath)
@@ -44,37 +44,24 @@ def CreateFigFolder(name, type):
 
 start = time.time()
 
-#INITIATE
-#######################################################################################################################
+# INITIATE
 path = path
 cmap = 'gnuplot2'
 
-#Read and seek
-reader=EventSource(input_url=path)
+# Read and seek
+reader = EventSource(input_url=path)
 seeker = EventSeeker(reader)
 reader1 = EventSource(input_url=path, max_events=1)
-#print(reader.file_list)
+# print(reader.file_list)
 
 name = GetName(path)
 ParentFolderName, ChildrenFolderName, FigPath = CreateFigFolder(name, 0)
-ResPath = NectarPath + 'output/%s/%s' %(ChildrenFolderName, name)
-#######################################################################################################################
+ResPath = NectarPath + 'output/%s/%s' % (ChildrenFolderName, name)
 
 
-
-
-                                                  ########################
-
-
-
-
-
-
-
-#LIST OF PROCESSES TO RUN
-#######################################################################################################################
+# LIST OF PROCESSES TO RUN
 a = TriggerStatistics(0)
-b = MeanWaveForms_HighLowGain(0) #0 is for high gain and 1 is for low gain
+b = MeanWaveForms_HighLowGain(0)  # 0 is for high gain and 1 is for low gain
 c = MeanWaveForms_HighLowGain(1)
 d = MeanCameraDisplay_HighLowGain(0)
 e = MeanCameraDisplay_HighLowGain(1)
@@ -92,20 +79,10 @@ processors.append(e)
 processors.append(f)
 processors.append(g)
 processors.append(h)
-#######################################################################################################################
 
 
-
-
-
-                                                 ########################
-
-
-
-
-#LIST OF DICT RESULTS
-#######################################################################################################################
-Results_MeanWaveForms_HighGain ={}
+# LIST OF DICT RESULTS
+Results_MeanWaveForms_HighGain = {}
 Results_MeanWaveForms_LowGain = {}
 Results_MeanCameraDisplay_HighGain = {}
 Results_MeanCameraDisplay_LowGain = {}
@@ -114,35 +91,29 @@ Results_ChargeIntegration_LowGain = {}
 Results_TriggerStatistics = {}
 Results_CameraMonitoring = {}
 
-NESTED_DICT = {} #The final results dictionary
-NESTED_DICT_KEYS = ["Results_TriggerStatistics", "Results_MeanWaveForms_HighGain", "Results_MeanWaveForms_LowGain", "Results_MeanCameraDisplay_HighGain", "Results_MeanCameraDisplay_LowGain", "Results_ChargeIntegration_HighGain", "Results_ChargeIntegration_LowGain", "Results_CameraMonitoring"]
-#NESTED_DICT_KEYS = ["Results_CameraMonitoring"]
+NESTED_DICT = {}  # The final results dictionary
+NESTED_DICT_KEYS = ["Results_TriggerStatistics", "Results_MeanWaveForms_HighGain",
+                    "Results_MeanWaveForms_LowGain",
+                    "Results_MeanCameraDisplay_HighGain",
+                    "Results_MeanCameraDisplay_LowGain",
+                    "Results_ChargeIntegration_HighGain",
+                    "Results_ChargeIntegration_LowGain", "Results_CameraMonitoring"]
+# NESTED_DICT_KEYS = ["Results_CameraMonitoring"]
 
-
-#######################################################################################################################
-
-
-
-
-                                                  ########################
-
-
-
-#START
-#######################################################################################################################
+# START
 for p in processors:
     Chan, Samp = p.DefineForRun(reader1)
     break
-    
-for p in processors:  
+
+for p in processors:
     p.ConfigureForRun(path, Chan, Samp, reader1)
 
 for i, evt in enumerate(reader):
-	for p in processors:
-		p.ProcessEvent(evt)
+    for p in processors:
+        p.ProcessEvent(evt)
 
 for arg in sys.argv[2:]:
-    reader=EventSource(input_url=arg)
+    reader = EventSource(input_url=arg)
     seeker = EventSeeker(reader)
 
     for i, evt in enumerate(reader):
@@ -154,32 +125,31 @@ for p in processors:
 
 dict_num = 0
 for p in processors:
-    NESTED_DICT[NESTED_DICT_KEYS[dict_num]] = p.GetResults() #True if want to compute plots, sedond true if want to save results
+    # True if want to compute plots, sedond true if want to save results
+    NESTED_DICT[NESTED_DICT_KEYS[dict_num]] = p.GetResults()
     dict_num += 1
 
-
-name = name #in order to allow to change the name easily
-p.WriteAllResults(ResPath, NESTED_DICT) #if we want to write all results in 1 pickle file we do this. 
+# in order to allow to change the name easily
+name = name
+# if we want to write all results in 1 pickle file we do this.
+p.WriteAllResults(ResPath, NESTED_DICT)
 
 for p in processors:
-    processor_figure_dict, processor_figure_name_dict  = p.PlotResults(name, FigPath)
+    processor_figure_dict, processor_figure_name_dict = p.PlotResults(name, FigPath)
 
     for fig_plot in processor_figure_dict:
         fig = processor_figure_dict[fig_plot]
         SavePath = processor_figure_name_dict[fig_plot]
         plt.gcf()
         fig.savefig(SavePath)
-        
+
 plt.clf()
 plt.cla()
 plt.close()
 
-
 end = time.time()
-print("Processing time:", end-start)
+print("Processing time:", end - start)
 
-#TODOS
-#######################################################################################################################
-#Reduce code by using loops: for figs and results
-#MONGO: store results 
-
+# TODOS
+# Reduce code by using loops: for figs and results
+# MONGO: store results

--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -1,19 +1,21 @@
-
-from dqm_summary_processor import *
 import math
+from matplotlib import pyplot as plt
+import numpy as np
+from astropy import time as astropytime
+from dqm_summary_processor import dqm_summary
+
 
 class TriggerStatistics(dqm_summary):
 
     def __init__(self, gaink):
-
         self.k = gaink
         return None
 
-    def ConfigureForRun(self,path, Chan, Samp, Reader1):
-        #define number of channels and samples
+    def ConfigureForRun(self, path, Chan, Samp, Reader1):
+        # define number of channels and samples
         self.Chan = Chan
-        self.Samp= Samp
-        
+        self.Samp = Samp
+
         self.event_type = []
         self.event_times = []
         self.event_id = []
@@ -25,12 +27,10 @@ class TriggerStatistics(dqm_summary):
         trigger_id = evt.index.event_id
         trigger_run_time = evt.nectarcam.tel[0].svc.date
 
-
         self.event_type.append(trigger_type)
         self.event_times.append(trigger_time)
         self.event_id.append(trigger_id)
         self.run_times.append(trigger_run_time)
-
 
     def FinishRun(self):
         self.triggers = np.unique(self.event_type)
@@ -44,10 +44,10 @@ class TriggerStatistics(dqm_summary):
 
         self.run_start1 = self.run_times[self.event_id == np.min(self.event_id)]
 
-        #Choose between the following two methods. time for max id can be sometimes 0.
-        #self.run_end = self.event_times[self.event_id == np.max(self.event_id)]
+        # Choose between the following two methods. time for max id can be sometimes 0.
+        # self.run_end = self.event_times[self.event_id == np.max(self.event_id)]
         self.run_start = self.event_times[self.event_id == np.min(self.event_id)]
-        #self.run_start = np.min(self.event_times)
+        # self.run_start = np.min(self.event_times)
         self.run_end = np.max(self.event_times)
 
         self.event_ped_times = self.event_times[self.event_type == pedestal_num]
@@ -60,41 +60,50 @@ class TriggerStatistics(dqm_summary):
         mask = ((self.event_type != physical_num) & (self.event_type != pedestal_num))
         self.event_other_id = self.event_id[mask]
 
-        self.event_ped_times = self.event_ped_times[self.event_ped_times > self.run_start]
-        self.event_phy_times = self.event_phy_times[self.event_phy_times > self.run_start]
-        self.event_other_times = self.event_other_times[self.event_other_times > self.run_start]
+        self.event_ped_times = self.event_ped_times[
+            self.event_ped_times > self.run_start]
+        self.event_phy_times = self.event_phy_times[
+            self.event_phy_times > self.run_start]
+        self.event_other_times = self.event_other_times[
+            self.event_other_times > self.run_start]
         self.event_wrong_times = self.event_times[self.event_times < self.run_start]
         self.event_times = self.event_times[self.event_times > self.run_start]
 
-
-    
     def GetResults(self):
         self.TriggerStat_Results_Dict = {}
         self.TriggerStat_Results_Dict["TRIGGER-TYPES"] = self.triggers
-        self.TriggerStat_Results_Dict["TRIGGER-STATISTICS"] = "All: %s, Physical: %s, Pedestals: %s, Others: %s, Wrong times: %s" %(len(self.event_times), len(self.event_phy_times), len(self.event_ped_times), len(self.event_other_times), len(self.event_wrong_times))
-        self.TriggerStat_Results_Dict["START-TIMES"] = "Run start time: %s, First event: %s, Last event: %s" %(self.run_start1, self.run_start, self.run_end)
+        self.TriggerStat_Results_Dict[
+            "TRIGGER-STATISTICS"
+        ] = "All: %s, Physical: %s, Pedestals: %s, Others: %s, Wrong times: %s" % (
+            len(self.event_times), len(self.event_phy_times), len(self.event_ped_times),
+            len(self.event_other_times), len(self.event_wrong_times)
+        )
+        self.TriggerStat_Results_Dict[
+            "START-TIMES"] = "Run start time: %s, First event: %s, Last event: %s" % \
+                             (self.run_start1, self.run_start, self.run_end)
         return self.TriggerStat_Results_Dict
 
-
-    def PlotResults(self,name,FigPath):
-
+    def PlotResults(self, name, FigPath):
         w = 1
-        n1 = np.array(self.event_times.max() - self.event_times.min(), dtype= object)
-        n = math.ceil(n1/w)
+        n1 = np.array(self.event_times.max() - self.event_times.min(), dtype=object)
+        n = math.ceil(n1 / w)
 
         self.TriggerStat_Figures_Dict = {}
         self.TriggerStat_Figures_Names_Dict = {}
         fig1, ax = plt.subplots()
-        ax.hist(self.event_type, 100, color = 'r', linewidth=1, log = True, alpha = 1, label = 'Trigger types')
+        ax.hist(self.event_type, 100, color='r', linewidth=1, log=True, alpha=1,
+                label='Trigger types')
         for rect in ax.patches:
             height = rect.get_height()
-            ax.annotate(f'{int(height)}', xy=(rect.get_x()+rect.get_width()/2, height), xytext=(0, 5), textcoords='offset points', ha='center', va='bottom') 
+            ax.annotate(f'{int(height)}',
+                        xy=(rect.get_x() + rect.get_width() / 2, height), xytext=(0, 5),
+                        textcoords='offset points', ha='center', va='bottom')
         plt.xticks(self.triggers)
         plt.title("Trigger Statistics")
         plt.xlabel("Trigger type")
         plt.grid()
-        full_name = name + '_Trigger_Statistics.png'  
-        FullPath = FigPath +full_name
+        full_name = name + '_Trigger_Statistics.png'
+        FullPath = FigPath + full_name
 
         self.TriggerStat_Figures_Dict["TRIGGER-STATISTICS"] = fig1
         self.TriggerStat_Figures_Names_Dict["TRIGGER-STATISTICS"] = FullPath
@@ -102,45 +111,63 @@ class TriggerStatistics(dqm_summary):
 
         w = 15
         n1 = self.event_times.max() - self.event_times.min()
-        n = math.ceil(n1/w)
-
+        n = math.ceil(n1 / w)
 
         fig2, ax = plt.subplots()
-        ax.hist(self.event_times - self.run_start, n, color = 'grey', linewidth=1, log = True, alpha = 0.5, label = 'All events (%s + %s invisible)' %(len(self.event_times), len(self.event_wrong_times)))
-        ax.hist(self.event_phy_times - self.run_start, n, color = 'cyan', linewidth=1, log = True, alpha = 0.5, label = 'Physical events (%s)' %len(self.event_phy_times))
-        ax.hist(self.event_ped_times - self.run_start, n, color = 'orange', linewidth=1, log = True, alpha = 0.5, label = 'Pedestal events (%s)' %len(self.event_ped_times))
-        ax.hist(self.event_other_times - self.run_start, n, color = 'brown', linewidth=1, log = True, alpha = 0.5, label = 'Other events (%s)' %len(self.event_other_times))
+        ax.hist(self.event_times - self.run_start, n, color='grey',
+                linewidth=1, log=True, alpha=0.5,
+                label='All events (%s + %s invisible)' %
+                      (len(self.event_times), len(self.event_wrong_times))
+                )
+        ax.hist(self.event_phy_times - self.run_start, n, color='cyan',
+                linewidth=1, log=True, alpha=0.5,
+                label='Physical events (%s)' % len(self.event_phy_times)
+                )
+        ax.hist(self.event_ped_times - self.run_start, n, color='orange', linewidth=1,
+                log=True, alpha=0.5,
+                label='Pedestal events (%s)' % len(self.event_ped_times))
+        ax.hist(self.event_other_times - self.run_start, n, color='brown', linewidth=1,
+                log=True, alpha=0.5,
+                label='Other events (%s)' % len(self.event_other_times))
         plt.legend()
         plt.xlabel("Time")
         plt.grid()
-        plt.title("Trigger rates, run start at %s" %astropytime.Time(self.run_start, format='unix').iso)
-        full_name = name + '_Event_rate.png'  
-        FullPath = FigPath +full_name
+        plt.title(
+            "Trigger rates, run start at %s" % astropytime.Time(
+                self.run_start, format='unix'
+            ).iso
+        )
+        full_name = name + '_Event_rate.png'
+        FullPath = FigPath + full_name
 
         self.TriggerStat_Figures_Dict["EVENT-TIME"] = fig2
         self.TriggerStat_Figures_Names_Dict["EVENT-TIME"] = FullPath
         plt.close()
 
         fig3, ax = plt.subplots()
-        ax.hist(self.event_id, n, color = 'grey', linewidth=1, log = True, alpha = 0.5, label = 'All events (%s)' %len(self.event_id))
-        ax.hist(self.event_phy_id, n, color = 'orange', linewidth=1, log = True, alpha = 0.5, label = 'Physical events (%s)' %len(self.event_phy_id))
-        ax.hist(self.event_ped_id, n, color = 'cyan', linewidth=1, log = True, alpha = 0.5, label = 'Pedestal events (%s)' %len(self.event_ped_id))
-        ax.hist(self.event_other_id, n, color = 'brown', linewidth=1, log = True, alpha = 0.5, label = 'Other events (%s)' %len(self.event_other_id))
+        ax.hist(self.event_id, n, color='grey', linewidth=1, log=True, alpha=0.5,
+                label='All events (%s)' % len(self.event_id))
+        ax.hist(self.event_phy_id, n, color='orange', linewidth=1, log=True, alpha=0.5,
+                label='Physical events (%s)' % len(self.event_phy_id))
+        ax.hist(self.event_ped_id, n, color='cyan', linewidth=1, log=True, alpha=0.5,
+                label='Pedestal events (%s)' % len(self.event_ped_id))
+        ax.hist(self.event_other_id, n, color='brown', linewidth=1, log=True, alpha=0.5,
+                label='Other events (%s)' % len(self.event_other_id))
         plt.legend()
         plt.xlabel("ID")
         plt.grid()
-        plt.title("Trigger IDs, run start at %s" %astropytime.Time(self.run_start, format='unix').iso)
-        full_name = name + '_Event_IDs.png'  
-        FullPath = FigPath +full_name
+        plt.title("Trigger IDs, run start at %s" % astropytime.Time(self.run_start,
+                                                                    format='unix').iso)
+        full_name = name + '_Event_IDs.png'
+        FullPath = FigPath + full_name
 
         self.TriggerStat_Figures_Dict["EVENT-ID"] = fig3
         self.TriggerStat_Figures_Names_Dict["EVENT-ID"] = FullPath
         plt.close()
 
-        return  self.TriggerStat_Figures_Dict, self.TriggerStat_Figures_Names_Dict
+        return self.TriggerStat_Figures_Dict, self.TriggerStat_Figures_Names_Dict
 
-#TODO
-#continue GetResults
-#adjust histogram displays
-#Choose between starting since run star time or event start time ?
-
+# TODO
+# continue GetResults
+# adjust histogram displays
+# Choose between starting since run star time or event start time ?


### PR DESCRIPTION
This PR formats the `nectarchain` code style with flake8!

-  Currently, the modules that are in `src/nectarchain/dqm/` directory are formatted. 
- The most common the flake8 errors were following :
   - E225 missing whitespace around operator
   - W291 trailing whitespace
   - E302 expected 2 blank lines
   - E265 block comment should start with '# '
   - E251 unexpected spaces around keyword / parameter equals
   - F405 'from module import *' used
   - E501 line too long (> 88 characters)
   - F841 local variable 'TempData' is assigned to but never used
   - F401 module imported but unused
   - E122 continuation line missing indentation or outdented
   