### PR TITLE
Enable all ctapipe charge extractors

### DIFF
--- a/src/nectarchain/user_scripts/ggrolleron/load_wfs_compute_charge.py
+++ b/src/nectarchain/user_scripts/ggrolleron/load_wfs_compute_charge.py
@@ -80,7 +80,14 @@ parser.add_argument('--overwrite',
 
 #extractor arguments
 parser.add_argument('--extractorMethod',
-                    choices=["FullWaveformSum","LocalPeakWindowSum"],
+                    choices=["FullWaveformSum",
+                             "FixedWindowSum",
+                             "GlobalPeakWindowSum",
+                             "LocalPeakWindowSum",
+                             "SlidingWindowMaxSum",
+                             "NeighborPeakWindowSum",
+                             "BaselineSubtractedNeighborPeakWindowSum",
+                             "TwoPassWindowSum"],
                     default="LocalPeakWindowSum",
                     help='charge extractor method',
                     type=str


### PR DESCRIPTION
This PR enables all possible charge extractors currently implemented in [ctapipe](https://cta-observatory.github.io/ctapipe/ctapipe_api/image/extractor.html#image-extraction-methods).