### PR TITLE
Apptainer CI

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           apptainer build nectarchain.sif singularity/Singularity
           # echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.REGISTRY }} 
-          echo "apptainer push nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          apptainer push nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          CMD="apptainer push -U --no-https nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          echo $CMD
+          $CMD
           # apptainer remote logout oras://${{ env.REGISTRY }}

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -15,6 +15,8 @@ jobs:
   deploy-container:
     runs-on: ubuntu-latest
 
+    permissions: write
+
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -35,12 +37,13 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
         # TODO CHANGE REPO HERE !!
         run: |
           apptainer build nectarchain.sif singularity/Singularity
           # echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.REGISTRY }} 
+          echo "apptainer push nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           apptainer push nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           # apptainer remote logout oras://${{ env.REGISTRY }}

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -11,7 +11,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-permissions: write
+permissions:
+  packages:
+    write
 
 jobs:
   deploy-container:

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -65,4 +65,4 @@ jobs:
         # TODO: Ultimately only push on non-pull-request event
         # if: github.event_name != 'pull_request'
         run: |  
-          apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}"
+          apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -7,11 +7,11 @@ on:
   #    - 'v*'
   pull_request:
 
+permissions: read-all|write-all
+
 jobs:
   deploy-container:
     runs-on: ubuntu-latest
-
-    permissions: read|write
 
     defaults:
       run:

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -1,0 +1,33 @@
+name: Build and deploy as Apptainer container image to GitHub Container Registry
+
+on:
+  push:
+  #  tags:
+  #    - 'v*'
+  pull_request:
+
+jobs:
+  deploy-container:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Set up Apptainer environment
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.1.7
+
+      - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
+        run: |
+          apptainer build nectarchain.sif singularity/Singularity
+          # Login to GitHub Container Registry
+          echo ${{secrets.ghcr_token}} | apptainer remote login --username ${{secrets.ghcr_username}} --password-stdin oras://ghcr.io
+          apptainer push nectarchain.sif oras://ghcr.io/cta-observatory/nectarchain:latest

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -25,9 +25,14 @@ jobs:
         with:
           apptainer-version: 1.1.7
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
         run: |
           apptainer build nectarchain.sif singularity/Singularity
-          # Login to GitHub Container Registry
-          echo ${{secrets.ghcr_token}} | apptainer remote login --username ${{secrets.ghcr_username}} --password-stdin oras://ghcr.io
           apptainer push nectarchain.sif oras://ghcr.io/cta-observatory/nectarchain:latest

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -11,12 +11,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions: write
+
 jobs:
   deploy-container:
     runs-on: ubuntu-latest
-
-    permissions: write
-
+    
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -35,5 +35,6 @@ jobs:
       - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
         run: |
           apptainer build nectarchain.sif singularity/Singularity
-          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login--username ${{ github.actor }} --password-stdin oras://ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://ghcr.io
           apptainer push nectarchain.sif oras://ghcr.io/cta-observatory/nectarchain:${{ github.event.release.tag_name }}
+          apptainer remote logout oras://ghcr.io

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -11,7 +11,7 @@ jobs:
   deploy-container:
     runs-on: ubuntu-latest
 
-    permissions: read-all|write-all
+    permissions: read|write
 
     defaults:
       run:

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -10,7 +10,7 @@ on:
     types: [ published ]
 
 jobs:
-  deploy-container:
+  build-deploy-container:
     runs-on: ubuntu-latest
     
     defaults:
@@ -27,7 +27,7 @@ jobs:
 
     env:
       container: nectarchain
-      registry: oras://ghcr.io
+      registry: ghcr.io
 
     steps:
       - name: Checkout
@@ -65,4 +65,4 @@ jobs:
         # TODO: Ultimately only push on non-pull-request event
         # if: github.event_name != 'pull_request'
         run: |  
-          apptainer push ${{ env.container }}.sif ${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}"
+          apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}"

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -7,8 +7,6 @@ on:
   #    - 'v*'
   pull_request:
 
-permissions: read-all|write-all
-
 jobs:
   deploy-container:
     runs-on: ubuntu-latest
@@ -40,5 +38,5 @@ jobs:
         run: |
           apptainer build nectarchain.sif singularity/Singularity
           echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://ghcr.io 
-          apptainer push nectarchain.sif oras://ghcr.io/jlenain/nectarchain:${{ github.event.release.tag_name }}
+          apptainer push nectarchain.sif oras://ghcr.io/jlenain/nectarchain:latest
           apptainer remote logout oras://ghcr.io

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -7,6 +7,10 @@ on:
   #    - 'v*'
   pull_request:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   deploy-container:
     runs-on: ubuntu-latest
@@ -26,17 +30,17 @@ jobs:
         with:
           apptainer-version: 1.1.7
 
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
         # TODO CHANGE REPO HERE !!
         run: |
           apptainer build nectarchain.sif singularity/Singularity
-          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://ghcr.io 
-          apptainer push nectarchain.sif oras://ghcr.io/jlenain/nectarchain:latest
-          apptainer remote logout oras://ghcr.io
+          # echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.REGISTRY }} 
+          apptainer push nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          # apptainer remote logout oras://${{ env.REGISTRY }}

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -54,11 +54,8 @@ jobs:
         # Don't log into registry on pull request.
         # TODO: ultimately only push on non-pull-request events !!!
         # if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+        run: |
+          echo ${{ github.token }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.registry }}
 
       - name: Deploy ${{ matrix.deffiles[1] }}
         # And don't push the container on a pull request.
@@ -66,3 +63,11 @@ jobs:
         # if: github.event_name != 'pull_request'
         run: |  
           apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}
+
+      - name: Post Login to GitHub Container Registry
+        # Don't log into registry on pull request.
+        # TODO: ultimately only push on non-pull-request events !!!
+        # if: github.event_name != 'pull_request'
+        run: |
+          apptainer remote logout oras://${{ env.registry }}
+

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -3,9 +3,8 @@ name: Build and deploy as Apptainer container image to GitHub Container Registry
 on:
   pull_request: []
   push:
-  # TODO CHANGE EVENT TRIGGERING TYPE !!!
-#    branches:
-#      - master
+    branches:
+      - master
   release:
     types: [ published ]
 
@@ -48,26 +47,22 @@ jobs:
               exit 1
           fi
           apptainer build ${{ env.container }}.sif ${{ matrix.deffiles[0] }}
-          ls
+          ls -lh
           
       - name: Login to GitHub Container Registry
         # Don't log into registry on pull request.
-        # TODO: ultimately only push on non-pull-request events !!!
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           echo ${{ github.token }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.registry }}
 
       - name: Deploy ${{ matrix.deffiles[1] }}
-        # And don't push the container on a pull request.
-        # TODO: Ultimately only push on non-pull-request event
-        # if: github.event_name != 'pull_request'
+        # Don't push the container on a pull request.
+        if: github.event_name != 'pull_request'
         run: |  
           apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}
 
       - name: Post Login to GitHub Container Registry
-        # Don't log into registry on pull request.
-        # TODO: ultimately only push on non-pull-request events !!!
-        # if: github.event_name != 'pull_request'
+        # Don't log out from registry on pull request.
+        if: github.event_name != 'pull_request'
         run: |
           apptainer remote logout oras://${{ env.registry }}
-

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -11,6 +11,8 @@ jobs:
   deploy-container:
     runs-on: ubuntu-latest
 
+    permissions: read-all|write-all
+
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -2,6 +2,7 @@ name: Build and deploy as Apptainer container image to GitHub Container Registry
 
 on:
   push:
+  # TODO CHANGE EVENT TRIGGERING TYPE !!!
   #  tags:
   #    - 'v*'
   pull_request:
@@ -33,8 +34,9 @@ jobs:
 #          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
+        # TODO CHANGE REPO HERE !!
         run: |
           apptainer build nectarchain.sif singularity/Singularity
-          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://ghcr.io
-          apptainer push nectarchain.sif oras://ghcr.io/cta-observatory/nectarchain:${{ github.event.release.tag_name }}
+          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://ghcr.io 
+          apptainer push nectarchain.sif oras://ghcr.io/jlenain/nectarchain:${{ github.event.release.tag_name }}
           apptainer remote logout oras://ghcr.io

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -1,19 +1,13 @@
 name: Build and deploy as Apptainer container image to GitHub Container Registry
 
 on:
+  pull_request: []
   push:
   # TODO CHANGE EVENT TRIGGERING TYPE !!!
-  #  tags:
-  #    - 'v*'
-  pull_request:
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
-permissions:
-  packages:
-    write
+#    branches:
+#      - master
+  release:
+    types: [ published ]
 
 jobs:
   deploy-container:
@@ -23,30 +17,52 @@ jobs:
       run:
         shell: bash -leo pipefail {0}
 
+    permissions:
+      packages:
+        write
+
+    strategy:
+      matrix:
+        deffiles: [[singularity/Singularity, latest]]
+
+    env:
+      container: nectarchain
+      registry: oras://ghcr.io
+
     steps:
-      - name: Check out the repo
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
-      - name: Set up Apptainer environment
+      - name: Setup Apptainer
         uses: eWaterCycle/setup-apptainer@v2
         with:
           apptainer-version: 1.1.7
 
+      - name: Build ${{ matrix.deffiles[1] }}
+        run: |
+          echo "Preparing to build ${{ env.container }} from ${{ matrix.deffiles[0] }}"
+          if [ ! -f "${{ matrix.deffiles[0]}}" ]; then
+              echo "Singularity definition file ${{ matrix.deffiles[0] }} does not exist"
+              exit 1
+          fi
+          apptainer build ${{ env.container }}.sif ${{ matrix.deffiles[0] }}
+          ls
+          
       - name: Login to GitHub Container Registry
+        # Don't log into registry on pull request.
+        # TODO: ultimately only push on non-pull-request events !!!
+        # if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.registry }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
-        # TODO CHANGE REPO HERE !!
-        run: |
-          apptainer build nectarchain.sif singularity/Singularity
-          # echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.REGISTRY }} 
-          CMD="apptainer push -U --no-https nectarchain.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          echo $CMD
-          $CMD
-          # apptainer remote logout oras://${{ env.REGISTRY }}
+      - name: Deploy ${{ matrix.deffiles[1] }}
+        # And don't push the container on a pull request.
+        # TODO: Ultimately only push on non-pull-request event
+        # if: github.event_name != 'pull_request'
+        run: |  
+          apptainer push ${{ env.container }}.sif ${{ env.registry }}/${{ github.repository }}:${{ matrix.deffiles[1] }}"

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -25,14 +25,15 @@ jobs:
         with:
           apptainer-version: 1.1.7
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and deploy apptainer container image to GitHub Container Registry as ORAS
         run: |
           apptainer build nectarchain.sif singularity/Singularity
-          apptainer push nectarchain.sif oras://ghcr.io/cta-observatory/nectarchain:latest
+          echo ${{ secrets.GITHUB_TOKEN }} | apptainer remote login--username ${{ github.actor }} --password-stdin oras://ghcr.io
+          apptainer push nectarchain.sif oras://ghcr.io/cta-observatory/nectarchain:${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  deploy:
+  deploy-pypi:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -14,6 +14,12 @@
 Bootstrap: docker
 From: condaforge/mambaforge
 
+%setup
+    mkdir -p ${SINGULARITY_ROOTFS}/opt/cta/nectarchain
+
+%files
+    . /opt/cta/nectarchain
+
 # From https://github.com/hpcng/singularity/issues/5075#issuecomment-594391772
 %environment
     action="${0##*/}"
@@ -40,12 +46,13 @@ From: condaforge/mambaforge
     mamba update --quiet --name base conda mamba
 
     # Install nectarchain
-    mamba env create --quiet --file ./environment.yml --prefix /opt/conda/envs/nectarchain
+    mamba env create --quiet --file /opt/cta/nectarchain/environment.yml --prefix /opt/conda/envs/nectarchain
     mamba activate nectarchain
+    cd /opt/cta/nectarchain
     pip install -e .
 
     # Optionally install and configure DIRAC:
-    mamba install -y -c conda-forge dirac-grid
+    mamba install --quiet -y -c conda-forge dirac-grid
     conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses
     mamba deactivate
     mamba activate nectarchain

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -14,9 +14,6 @@
 Bootstrap: docker
 From: condaforge/mambaforge
 
-%files
-    environment.yml /tmp
-
 # From https://github.com/hpcng/singularity/issues/5075#issuecomment-594391772
 %environment
     action="${0##*/}"
@@ -47,7 +44,8 @@ From: condaforge/mambaforge
     cd /opt/cta
 
     # Install nectarchain
-    mamba env create --quiet --file /tmp/environment.yml --prefix /opt/conda/envs/nectarchain
+    git clone https://github.com/cta-observatory/nectarchain.git
+    mamba env create --quiet --file nectarchain/environment.yml --prefix /opt/conda/envs/nectarchain
     mamba activate nectarchain
     cd nectarchain
     pip install -e .

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -27,9 +27,7 @@ From: condaforge/mambaforge
     fi
 
 %post
-    ORIG=$PWD
-
-    # CA certificates
+    # Install CA certificates
     apt -y update
     # cf. https://serverfault.com/a/992421
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt -y install software-properties-common curl
@@ -40,14 +38,10 @@ From: condaforge/mambaforge
     . /opt/conda/etc/profile.d/conda.sh
     . /opt/conda/etc/profile.d/mamba.sh
     mamba update --quiet --name base conda mamba
-    mkdir -p /opt/cta
-    cd /opt/cta
 
     # Install nectarchain
-    git clone https://github.com/cta-observatory/nectarchain.git
-    mamba env create --quiet --file nectarchain/environment.yml --prefix /opt/conda/envs/nectarchain
+    mamba env create --quiet --file environment.yml --prefix /opt/conda/envs/nectarchain
     mamba activate nectarchain
-    cd nectarchain
     pip install -e .
 
     # Optionally install and configure DIRAC:

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -3,16 +3,19 @@
 # Built from mambaforge, with special conda environment containing nectarchain
 #
 # Jean-Philippe Lenain <jlenain@in2p3.fr>
-# Time-stamp: "2023-04-06 14:42:19 jlenain"
+# Time-stamp: "2023-04-08 00:20:24 jlenain"
 #
 # Typically, build this image with:
-# `sudo singularity build nectarchain.sif Singularity`
+# `sudo apptainer build nectarchain.sif singularity/Singularity`
 #
 # Then, typically run an instance of this image with:
-# `singularity shell nectarchain.sif`
+# `apptainer shell nectarchain.sif`
 
 Bootstrap: docker
 From: condaforge/mambaforge
+
+%files
+    environment.yml /tmp
 
 # From https://github.com/hpcng/singularity/issues/5075#issuecomment-594391772
 %environment
@@ -44,8 +47,7 @@ From: condaforge/mambaforge
     cd /opt/cta
 
     # Install nectarchain
-    git clone https://github.com/cta-observatory/nectarchain.git
-    mamba env create --quiet --file nectarchain/environment.yml --prefix /opt/conda/envs/nectarchain
+    mamba env create --quiet --file /tmp/environment.yml --prefix /opt/conda/envs/nectarchain
     mamba activate nectarchain
     cd nectarchain
     pip install -e .
@@ -55,9 +57,8 @@ From: condaforge/mambaforge
     conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses
     mamba deactivate
     mamba activate nectarchain
-    pip install CTADIRAC
-    pip install COMDIRAC
-    
+    pip install CTADIRAC COMDIRAC
+
     # Since there is no proxy available at build time, manually configure the CTADIRAC client
     cat <<EOF > ${CONDA_PREFIX}/etc/dirac.cfg
 DIRAC

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -40,7 +40,7 @@ From: condaforge/mambaforge
     mamba update --quiet --name base conda mamba
 
     # Install nectarchain
-    mamba env create --quiet --file environment.yml --prefix /opt/conda/envs/nectarchain
+    mamba env create --quiet --file ./environment.yml --prefix /opt/conda/envs/nectarchain
     mamba activate nectarchain
     pip install -e .
 


### PR DESCRIPTION
This PR introduces a new CI workflow where:

- `nectarchain` is shipped as a `conda` environment, and buit as an Apptainer/Singularity container on selected events (releases, pull requests, merges into `master`),
- the container is deployed on the GitHub Container Registry, i.e. visible as a package of the cta-observatory organization, on non-pull-request events, such as releases.

Users can then use such containers with:
```shell
apptainer shell oras://ghcr.io/cta-observatory/nectarchain:latest
```

**TL;DR**

We will now have fully automatic Apptainer containers built and deployed on releases!

@kosack , @maxnoe , would that be deemed acceptable ?