### PR TITLE
Introduce pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black-jupyter
+  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: [--max-line-length=88, "--extend-ignore=E203,E712"]

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - ctapipe-io-nectarcam
   - numpy=1.22 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - jupyterlab
+  - pre-commit
   - protozfits=2.0
   - pytables>=3.7
   - pytest-runner


### PR DESCRIPTION
This PR introduces [pre-commit](https://pre-commit.com/) hooks to our repository.

Following discussions with @sona-patel and #49 , in such a way, any new commit to the code will automatically:
* be linted using `black` and `flake8`, including for commits on Jupyter notebooks,
* see the different imports sorted using [isort](https://pycqa.github.io/isort/index.html), following @kosack 's recommendations.

provided that developers enable pre-commits with (see https://pre-commit.com/#quick-start):
```shell
pre-commit install
```

# TODO
* A very nice suggestion by @HealthyPear in https://github.com/cta-observatory/ctapipe_io_nectarcam/pull/40#issuecomment-1607141623 concerns adding a pre-commit hook to automatically convert Jupyter notebooks using `jupytext` (see e.g. https://jupytext.readthedocs.io/en/latest/using-pre-commit.html). Will do in a following commit in this PR.