### PR TITLE
Find runs on GRID directly with the Dirac python API

### DIFF
--- a/src/nectarchain/utils/__init__.py
+++ b/src/nectarchain/utils/__init__.py
@@ -1,3 +1,4 @@
 from .error import *
 from .io import *
+from .logger import *
 from .utils import *

--- a/src/nectarchain/utils/__init__.py
+++ b/src/nectarchain/utils/__init__.py
@@ -1,2 +1,3 @@
 from .error import *
+from .io import *
 from .utils import *

--- a/src/nectarchain/utils/io.py
+++ b/src/nectarchain/utils/io.py
@@ -13,8 +13,9 @@ class StdoutRecord:
         self.output = []
 
     def write(self, message):
-        # self.console.write(message)
         if self.keyword in message:
+            self.console.write(message)
+            self.console.write("\n")
             self.output.append(message)
 
     def flush(self):

--- a/src/nectarchain/utils/io.py
+++ b/src/nectarchain/utils/io.py
@@ -1,0 +1,21 @@
+import logging
+import sys
+
+logging.basicConfig(format="%(asctime)s %(name)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+log.handlers = logging.getLogger("__main__").handlers
+
+
+class StdoutRecord:
+    def __init__(self, keyword):
+        self.console = sys.stdout
+        self.keyword = keyword
+        self.output = []
+
+    def write(self, message):
+        # self.console.write(message)
+        if self.keyword in message:
+            self.output.append(message)
+
+    def flush(self):
+        self.console.flush()

--- a/src/nectarchain/utils/logger.py
+++ b/src/nectarchain/utils/logger.py
@@ -1,0 +1,27 @@
+import logging
+
+logging.basicConfig(format="%(asctime)s %(name)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+log.handlers = logging.getLogger("__main__").handlers
+
+import copy
+
+
+class KeepLoggingUnchanged:
+    def __init__(self):
+        self._nameToLevel = None
+        self._levelToName = None
+        self._srcfile = None
+        # self._lock = None
+
+    def __enter__(self):
+        self._nameToLevel = copy.copy(logging._nameToLevel)
+        self._levelToName = copy.copy(logging._levelToName)
+        self._srcfile = copy.copy(logging._srcfile)
+        # self._lock = copy.copy(logging._lock)
+
+    def __exit__(self, type, value, traceback):
+        logging._levelToName = self._levelToName
+        logging._nameToLevel = self._nameToLevel
+        logging._srcfile = self._srcfile
+        # logging._lock = self._lock


### PR DESCRIPTION
I just changed the way to access the runs files stored on the GRID, before we had to access the ELog and the method was not robust. 

Now we directly use the DIRAC API to search and find location of data with run number.

This feature makes possible to use `tools` and do not need to previously download runs files locally in $NECTARCAMDATA. `nectarchain` will check if the files are accessible locally, if not, it will automatically fetch them from the GRID and store them in ¤NECTARCAMDATA