### PR TITLE
Publish release tags for containers, on release

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           apptainer-version: 1.1.7
 
-      - name: Build ${{ matrix.deffiles[1] }}
+      - name: Build ${{ env.container }} container
         run: |
           echo "Preparing to build ${{ env.container }} from ${{ matrix.deffiles[0] }}"
           if [ ! -f "${{ matrix.deffiles[0]}}" ]; then
@@ -55,7 +55,12 @@ jobs:
         run: |
           echo ${{ github.token }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.registry }}
 
-      - name: Deploy ${{ matrix.deffiles[1] }}
+      - name: Deploy ${{ env.container }} container
+        # Assign the release tag to container on release
+        if: github.event_name == 'release'
+        run: |
+          apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ github.ref }}
+        # Otherwise, the container tag is "latest" by default.
         # Don't push the container on a pull request.
         if: github.event_name != 'pull_request'
         run: |  

--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -55,11 +55,13 @@ jobs:
         run: |
           echo ${{ github.token }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.registry }}
 
-      - name: Deploy ${{ env.container }} container
+      - name: Deploy ${{ env.container }} container ${{ github.ref }}
         # Assign the release tag to container on release
         if: github.event_name == 'release'
         run: |
           apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ github.ref }}
+
+      - name: Deploy ${{ env.container }} container ${{ matrix.deffiles[1] }}
         # Otherwise, the container tag is "latest" by default.
         # Don't push the container on a pull request.
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This PR adds the possibility to publish release tags, on releases, for containers. Doing so, the users will have a better visibility on which `nectarchain` version they are instantiating:

```shell
apptainer shell oras://ghcr.io/cta-observatory/nectarchain:v0.1.7
```
instead of just:
```shell
apptainer shell oras://ghcr.io/cta-observatory/nectarchain
```

Before, to pin a particular version during the instantiation, one had to provide a specific SHA256 hash, such as:
```shell
apptainer shell oras://ghcr.io/cta-observatory/nectarchain:sha256:94c18526e2095b6d4bff17cef3f9a50ffb6e46f84b1e55ea5d0ae56c55abf90b
```
which was not very handy...