### PR TITLE
Publish release tags for containers, on release (continued)

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -55,11 +55,11 @@ jobs:
         run: |
           echo ${{ github.token }} | apptainer remote login --username ${{ github.actor }} --password-stdin oras://${{ env.registry }}
 
-      - name: Deploy ${{ env.container }} container ${{ github.ref }}
+      - name: Deploy ${{ env.container }} container ${{ github.ref_name }}
         # Assign the release tag to container on release
         if: github.event_name == 'release'
         run: |
-          apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ github.ref }}
+          apptainer push ${{ env.container }}.sif oras://${{ env.registry }}/${{ github.repository }}:${{ github.ref_name }}
 
       - name: Deploy ${{ env.container }} container ${{ matrix.deffiles[1] }}
         # Otherwise, the container tag is "latest" by default.


### PR DESCRIPTION
Fixed the way to get tag name in GitHub Actions. This is a follow-up of #100 