### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         ctapipe-version: [v0.19.3]
         install-method: [ "mamba", "pip" ]
 

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mamba create -n nectarchain -c conda-forge nectarchain
 `nectarchain` can also be manually installed as a PyPI package, albeit following specific requirements which are automatically accounted for through a `conda`/`mamba` installation.
 
 ```shell
-mamba create -n nectarchain python=3.8
+mamba create -n nectarchain python=3.11
 mamba activate nectarchain
 pip install nectarchain
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "ctapipe~=0.19",
     "ctapipe-io-nectarcam",


### PR DESCRIPTION
In line with `protozfits` (see https://gitlab.cta-observatory.org/cta-computing/common/protozfits-python/-/commit/bf475ba48ecb3a443023ef667f409d588af17fc6), which is a dependency for `nectarchain`, we drop support for python 3.8.