### PR TITLE
Use setup-micromamba GitHub action instead of provision-with-micromamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Mamba setup
         if: matrix.install-method == 'mamba'
-        uses: mamba-org/provision-with-micromamba@v16
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: "ci"
           environment-file: environment.yml


### PR DESCRIPTION
This PR switches from setup-micromamba GitHub action, which has been deprecated, to provision-with-micromamba, as proposed in #138.