### PR TITLE
Pin scipy version to 1.11.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-runner
   - pip
   - pandas
-  - scipy=1.11
+  - scipy=1.11.4
   - sphinx
   - sphinx-automodapi
   - pydata-sphinx-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ctapipe~=0.19",
     "ctapipe-io-nectarcam",
     "pandas",
-    "scipy==1.11",
+    "scipy==1.11.4",
     "zodb",
     "zeo",
 ]


### PR DESCRIPTION
Pin scipy version to 1.11.4, to avoid failures such as https://github.com/cta-observatory/ctapipe_io_nectarcam/actions/runs/10183584596/job/28168887272?pr=54 when building ctapipe_io_nectarcam