### PR TITLE
DQM output format and parsing script

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -11,6 +11,7 @@ from ctapipe_io_nectarcam import constants
 
 NOTINDISPLAY = [
     "TRIGGER-.*",
+    "PED-INTEGRATION-.*",
     "START-TIMES",
     "WF-.*",
     ".*PixTimeline-.*",

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -13,7 +13,7 @@ NOTINDISPLAY = [
     "TRIGGER-",
     "START-TIMES",
     "WF-",
-    "PIXTIMELINE-",
+    "PixTimeline-",
 ]
 TEST_PATTERN = "(?:% s)" % "|".join(NOTINDISPLAY)
 

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -10,10 +10,10 @@ from ctapipe.visualization.bokeh import CameraDisplay
 from ctapipe_io_nectarcam import constants
 
 NOTINDISPLAY = [
-    "TRIGGER-",
+    "TRIGGER-.*",
     "START-TIMES",
-    "WF-",
-    "PixTimeline-",
+    "WF-.*",
+    ".*PixTimeline-.*",
 ]
 TEST_PATTERN = "(?:% s)" % "|".join(NOTINDISPLAY)
 

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -1,4 +1,5 @@
 import collections
+import re
 
 import numpy as np
 from ctapipe.coordinates import EngineeringCameraFrame
@@ -9,12 +10,11 @@ from ctapipe.visualization.bokeh import CameraDisplay
 from ctapipe_io_nectarcam import constants
 
 NOTINDISPLAY = [
-    "Results_TriggerStatistics",
-    "Results_MeanWaveForms_HighGain",
-    "Results_MeanWaveForms_LowGain",
-    "Results_PixelTimeline_HighGain",
-    "Results_PixelTimeline_LowGain",
+    "TRIGGER-",
+    "WF-",
+    "PIXTIMELINE-",
 ]
+TEST_PATTERN = "(?:% s)" % "|".join(NOTINDISPLAY)
 
 geom = CameraGeometry.from_name("NectarCam-003")
 geom = geom.transform_to(EngineeringCameraFrame())
@@ -28,7 +28,7 @@ def get_rundata(src, runid):
 def make_camera_displays(db, source, runid):
     displays = collections.defaultdict(dict)
     for parentkey in db[runid].keys():
-        if parentkey not in NOTINDISPLAY:
+        if not re.match(TEST_PATTERN, parentkey):
             for childkey in db[runid][parentkey].keys():
                 print(f"Run id {runid} Preparing plot for {parentkey}, {childkey}")
                 displays[parentkey][childkey] = make_camera_display(

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -28,8 +28,8 @@ def get_rundata(src, runid):
 def make_camera_displays(db, source, runid):
     displays = collections.defaultdict(dict)
     for parentkey in db[runid].keys():
-        if not re.match(TEST_PATTERN, parentkey):
-            for childkey in db[runid][parentkey].keys():
+        for childkey in db[runid][parentkey].keys():
+            if not re.match(TEST_PATTERN, childkey):
                 print(f"Run id {runid} Preparing plot for {parentkey}, {childkey}")
                 displays[parentkey][childkey] = make_camera_display(
                     source, parent_key=parentkey, child_key=childkey

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -11,6 +11,7 @@ from ctapipe_io_nectarcam import constants
 
 NOTINDISPLAY = [
     "TRIGGER-",
+    "START-TIMES",
     "WF-",
     "PIXTIMELINE-",
 ]

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -12,7 +12,8 @@ NOTINDISPLAY = [
     "Results_TriggerStatistics",
     "Results_MeanWaveForms_HighGain",
     "Results_MeanWaveForms_LowGain",
-    "Results_CameraMonitoring",
+    "Results_PixelTimeline_HighGain",
+    "Results_PixelTimeline_LowGain",
 ]
 
 geom = CameraGeometry.from_name("NectarCam-003")

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -1,5 +1,4 @@
 import collections
-import re
 
 import numpy as np
 from ctapipe.coordinates import EngineeringCameraFrame
@@ -10,11 +9,12 @@ from ctapipe.visualization.bokeh import CameraDisplay
 from ctapipe_io_nectarcam import constants
 
 NOTINDISPLAY = [
-    "TRIGGER-",
-    "WF-",
-    "PIXTIMELINE-",
+    "Results_TriggerStatistics",
+    "Results_MeanWaveForms_HighGain",
+    "Results_MeanWaveForms_LowGain",
+    "Results_PixelTimeline_HighGain",
+    "Results_PixelTimeline_LowGain",
 ]
-TEST_PATTERN = "(?:% s)" % "|".join(NOTINDISPLAY)
 
 geom = CameraGeometry.from_name("NectarCam-003")
 geom = geom.transform_to(EngineeringCameraFrame())
@@ -28,7 +28,7 @@ def get_rundata(src, runid):
 def make_camera_displays(db, source, runid):
     displays = collections.defaultdict(dict)
     for parentkey in db[runid].keys():
-        if not re.match(TEST_PATTERN, parentkey):
+        if parentkey not in NOTINDISPLAY:
             for childkey in db[runid][parentkey].keys():
                 print(f"Run id {runid} Preparing plot for {parentkey}, {childkey}")
                 displays[parentkey][childkey] = make_camera_display(

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -32,10 +32,18 @@ def update_camera_displays(attr, old, new):
                 image = np.nan_to_num(image, nan=0.0)
                 try:
                     displays[parentkey][childkey].image = image
-                except ValueError:
+                except ValueError as e:
+                    print(
+                        f"Caught error {e} for {childkey}, filling display with "
+                        f"zeros."
+                    )
                     image = np.zeros(shape=displays[parentkey][childkey].image.shape)
                     displays[parentkey][childkey].image = image
-                except KeyError:
+                except KeyError as e:
+                    print(
+                        f"Caught error {e} for {childkey}, filling display with "
+                        f"zeros."
+                    )
                     image = np.zeros(shape=constants.N_PIXELS)
                     displays[parentkey][childkey].image = image
                 # TODO: TRY TO USE `stream` INSTEAD, ON UPDATES:

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -1,7 +1,5 @@
-import re
-
 import numpy as np
-from app_hooks import TEST_PATTERN, get_rundata, make_camera_displays
+from app_hooks import NOTINDISPLAY, get_rundata, make_camera_displays
 
 # bokeh imports
 from bokeh.layouts import layout, row
@@ -24,7 +22,7 @@ def update_camera_displays(attr, old, new):
     new_rundata = get_rundata(db, runid)
 
     for parentkey in db[runid].keys():
-        if not re.match(TEST_PATTERN, parentkey):
+        if parentkey not in NOTINDISPLAY:
             for childkey in db[runid][parentkey].keys():
                 print(f"Run id {runid} Updating plot for {parentkey}, {childkey}")
                 # try:

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -24,8 +24,8 @@ def update_camera_displays(attr, old, new):
     new_rundata = get_rundata(db, runid)
 
     for parentkey in db[runid].keys():
-        if not re.match(TEST_PATTERN, parentkey):
-            for childkey in db[runid][parentkey].keys():
+        for childkey in db[runid][parentkey].keys():
+            if not re.match(TEST_PATTERN, childkey):
                 print(f"Run id {runid} Updating plot for {parentkey}, {childkey}")
                 # try:
                 image = new_rundata[parentkey][childkey]

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -45,7 +45,20 @@ def update_camera_displays(attr, old, new):
 
 db = DQMDB(read_only=True).root
 runids = sorted(list(db.keys()))
-runid = runids[-1]
+
+# First, get the run id with the most populated result dictionary
+runid_max = runids[-1]
+largest = 0
+for runid in runids:
+    larger = 0
+    for k in db[runid].keys():
+        length = len(db[runid][k])
+        if length > larger:
+            larger = length
+    if larger > largest:
+        largest = larger
+        runid_max = runid
+runid = runid_max
 
 # runid_input = NumericInput(value=db.root.keys()[-1], title="NectarCAM run number")
 run_select = Select(value=runid, title="NectarCAM run number", options=runids)

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -23,11 +23,16 @@ def update_camera_displays(attr, old, new):
     runid = run_select.value
     new_rundata = get_rundata(db, runid)
 
+    # Reset each display
+    for k in displays.keys():
+        for kk in displays[k].keys():
+            displays[k][kk].image = np.zeros(shape=constants.N_PIXELS)
+
     for parentkey in db[runid].keys():
         for childkey in db[runid][parentkey].keys():
             if not re.match(TEST_PATTERN, childkey):
                 print(f"Run id {runid} Updating plot for {parentkey}, {childkey}")
-                # try:
+
                 image = new_rundata[parentkey][childkey]
                 image = np.nan_to_num(image, nan=0.0)
                 try:

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -39,15 +39,15 @@ def update_camera_displays(attr, old, new):
                     displays[parentkey][childkey].image = image
                 except ValueError as e:
                     print(
-                        f"Caught {type(e).__name__} for {childkey}, filling display with "
-                        f"zeros. Details: {e}"
+                        f"Caught {type(e).__name__} for {childkey}, filling display"
+                        f"with zeros. Details: {e}"
                     )
                     image = np.zeros(shape=displays[parentkey][childkey].image.shape)
                     displays[parentkey][childkey].image = image
                 except KeyError as e:
                     print(
-                        f"Caught {type(e).__name__} for {childkey}, filling display with "
-                        f"zeros. Details: {e}"
+                        f"Caught {type(e).__name__} for {childkey}, filling display"
+                        f"with zeros. Details: {e}"
                     )
                     image = np.zeros(shape=constants.N_PIXELS)
                     displays[parentkey][childkey].image = image

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -1,4 +1,7 @@
+import re
+
 import numpy as np
+from app_hooks import TEST_PATTERN, get_rundata, make_camera_displays
 
 # bokeh imports
 from bokeh.layouts import layout, row
@@ -12,15 +15,6 @@ from ctapipe_io_nectarcam import constants
 
 from nectarchain.dqm.db_utils import DQMDB
 
-from .app_hooks import get_rundata, make_camera_displays
-
-NOTINDISPLAY = [
-    "Results_TriggerStatistics",
-    "Results_MeanWaveForms_HighGain",
-    "Results_MeanWaveForms_LowGain",
-    "Results_CameraMonitoring",
-]
-
 geom = CameraGeometry.from_name("NectarCam-003")
 geom = geom.transform_to(EngineeringCameraFrame())
 
@@ -30,7 +24,7 @@ def update_camera_displays(attr, old, new):
     new_rundata = get_rundata(db, runid)
 
     for parentkey in db[runid].keys():
-        if parentkey not in NOTINDISPLAY:
+        if not re.match(TEST_PATTERN, parentkey):
             for childkey in db[runid][parentkey].keys():
                 print(f"Run id {runid} Updating plot for {parentkey}, {childkey}")
                 # try:

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -1,5 +1,7 @@
+import re
+
 import numpy as np
-from app_hooks import NOTINDISPLAY, get_rundata, make_camera_displays
+from app_hooks import TEST_PATTERN, get_rundata, make_camera_displays
 
 # bokeh imports
 from bokeh.layouts import layout, row
@@ -22,7 +24,7 @@ def update_camera_displays(attr, old, new):
     new_rundata = get_rundata(db, runid)
 
     for parentkey in db[runid].keys():
-        if parentkey not in NOTINDISPLAY:
+        if not re.match(TEST_PATTERN, parentkey):
             for childkey in db[runid][parentkey].keys():
                 print(f"Run id {runid} Updating plot for {parentkey}, {childkey}")
                 # try:

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -34,15 +34,15 @@ def update_camera_displays(attr, old, new):
                     displays[parentkey][childkey].image = image
                 except ValueError as e:
                     print(
-                        f"Caught error {e} for {childkey}, filling display with "
-                        f"zeros."
+                        f"Caught {type(e).__name__} for {childkey}, filling display with "
+                        f"zeros. Details: {e}"
                     )
                     image = np.zeros(shape=displays[parentkey][childkey].image.shape)
                     displays[parentkey][childkey].image = image
                 except KeyError as e:
                     print(
-                        f"Caught error {e} for {childkey}, filling display with "
-                        f"zeros."
+                        f"Caught {type(e).__name__} for {childkey}, filling display with "
+                        f"zeros. Details: {e}"
                     )
                     image = np.zeros(shape=constants.N_PIXELS)
                     displays[parentkey][childkey].image = image

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -1,3 +1,4 @@
+import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 
@@ -38,7 +39,13 @@ class DQMSummary:
         try:
             data[name] = content
         except TypeError:
-            data = Table(content)
+            try:
+                data = Table(content)
+            except ValueError:
+                # We may have caught just a single float value, try to pack it into
+                # the FITS output
+                content = np.array([content])
+                data = Table(content)
         hdu = fits.BinTableHDU(data)
         hdu.name = name
         return hdu

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -40,7 +40,7 @@ class DQMSummary:
         hdu, hdu0, hdu1, hdu2 = None, None, None, None
         hdulist = fits.HDUList()
         for i, j in DICT.items():
-            if (i == "Results_TriggerStatistics"):
+            if i == "Results_TriggerStatistics":
                 for n2, m2 in j.items():
                     data2[n2] = m2
                     hdu2 = fits.BinTableHDU(data2)

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -32,47 +32,22 @@ class DQMSummary:
     ):
         print("Processor 5")
 
-    def WriteAllResults(self, path, DICT):
-        data2 = Table()
-        data1 = Table()
-        data0 = Table()
+    @staticmethod
+    def _create_hdu(name, content):
         data = Table()
-        hdu, hdu0, hdu1, hdu2 = None, None, None, None
+        data[name] = content
+        hdu = fits.BinTableHDU(data)
+        hdu.name = name
+        return hdu
+
+    def WriteAllResults(self, path, DICT):
         hdulist = fits.HDUList()
         for i, j in DICT.items():
-            if i == "Results_TriggerStatistics":
-                for n2, m2 in j.items():
-                    data2[n2] = m2
-                    hdu2 = fits.BinTableHDU(data2)
-                    hdu2.name = n2
-                    hdulist.append(hdu2)
-
-            elif (i == "Results_MeanWaveForms_HighGain") or (
-                i == "Results_MeanWaveForms_LowGain"
-            ):
-                for n1, m1 in j.items():
-                    data1[n1] = m1
-                    hdu1 = fits.BinTableHDU(data1)
-                    hdu1.name = n1
-                    hdulist.append(hdu1)
-
-            elif (i == "Results_PixelTimeline_HighGain") or (
-                i == "Results_PixelTimeline_LowGain"
-            ):
-                for n0, m0 in j.items():
-                    data0[n0] = m0
-                    hdu0 = fits.BinTableHDU(data0)
-                    hdulist.append(hdu0)
-
-            else:
-                for n, m in j.items():
-                    data[n] = m
-                    hdu = fits.BinTableHDU(data)
-                    hdu.name = n
-                    hdulist.append(hdu)
+            for name, content in j.items():
+                hdu = self._create_hdu(name, content)
+                hdulist.append(hdu)
 
         FileName = path + "_Results.fits"
         print(FileName)
         hdulist.writeto(FileName, overwrite=True)
         hdulist.info()
-        return None

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -43,47 +43,36 @@ class DQMSummary:
             if (i == "Results_TriggerStatistics"):
                 for n2, m2 in j.items():
                     data2[n2] = m2
-                hdu2 = fits.BinTableHDU(data2)
-                hdu2.name = "Trigger"
+                    hdu2 = fits.BinTableHDU(data2)
+                    hdu2.name = n2
+                    hdulist.append(hdu2)
 
             elif (i == "Results_MeanWaveForms_HighGain") or (
                 i == "Results_MeanWaveForms_LowGain"
             ):
                 for n1, m1 in j.items():
                     data1[n1] = m1
-                hdu1 = fits.BinTableHDU(data1)
-                hdu1.name = "MWF"    
+                    hdu1 = fits.BinTableHDU(data1)
+                    hdu1.name = n1
+                    hdulist.append(hdu1)
 
-            elif (i == "Results_PixelTimeline_HighGain") or (i == "Results_PixelTimeline_LowGain"):
+            elif (i == "Results_PixelTimeline_HighGain") or (
+                i == "Results_PixelTimeline_LowGain"
+            ):
                 for n0, m0 in j.items():
-                    data0[n0] = m0 
-                hdu0 = fits.BinTableHDU(data0)
-                hdu0.name = "BPX"
+                    data0[n0] = m0
+                    hdu0 = fits.BinTableHDU(data0)
+                    hdulist.append(hdu0)
 
             else:
                 for n, m in j.items():
                     data[n] = m
-                hdu = fits.BinTableHDU(data)
-                hdu.name = "Camera"
-        if hdu2:
-            hdulist.append(hdu2)
-        else:
-            print("No trigger statistics requests")
-        if hdu1:
-            hdulist.append(hdu1)
-        else:
-            print("No MWF studies requests")
-        if hdu0:
-            hdulist.append(hdu0)
-        else:
-            print("No Pixel Timeline studies requests")
-        if hdu:
-            hdulist.append(hdu)
-        else:
-            print("No Camera studies requests")
+                    hdu = fits.BinTableHDU(data)
+                    hdu.name = n
+                    hdulist.append(hdu)
 
-        
-        FileName = path + '_Results.fits'
+        FileName = path + "_Results.fits"
         print(FileName)
         hdulist.writeto(FileName, overwrite=True)
+        hdulist.info()
         return None

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -51,7 +51,7 @@ class DQMSummary:
                     hdu = self._create_hdu(name, content)
                     hdulist.append(hdu)
                 except TypeError as e:
-                    print(f"DEBUG JPL: Got error {e}, skipping {name}")
+                    print(f"Caught {type(e).__name__}, skipping {name}. Details: {e}")
                     pass
 
         FileName = path + "_Results.fits"

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -44,8 +44,12 @@ class DQMSummary:
         hdulist = fits.HDUList()
         for i, j in DICT.items():
             for name, content in j.items():
-                hdu = self._create_hdu(name, content)
-                hdulist.append(hdu)
+                try:
+                    hdu = self._create_hdu(name, content)
+                    hdulist.append(hdu)
+                except TypeError as e:
+                    print(f"DEBUG JPL: Got error {e}, skipping {name}")
+                    pass
 
         FileName = path + "_Results.fits"
         print(FileName)

--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -35,7 +35,10 @@ class DQMSummary:
     @staticmethod
     def _create_hdu(name, content):
         data = Table()
-        data[name] = content
+        try:
+            data[name] = content
+        except TypeError:
+            data = Table(content)
         hdu = fits.BinTableHDU(data)
         hdu.name = name
         return hdu

--- a/src/nectarchain/dqm/start_dqm.py
+++ b/src/nectarchain/dqm/start_dqm.py
@@ -70,8 +70,6 @@ def main():
     output_path = args.output_paths
     print("Output path:", output_path)
 
-    # Defining and printing the paths of the input files.
-
     if args.runnb is not None:
         # Grab runs automatically from DIRAC is the -r option is provided
         from nectarchain.data.management import DataManagement
@@ -151,35 +149,23 @@ def main():
     ResPath = f"{output_path}/output/{ChildrenFolderName}/{name}"
 
     # LIST OF PROCESSES TO RUN
-    ####################################################################################
-    a = TriggerStatistics(HIGH_GAIN)
-    b = MeanWaveFormsHighLowGain(HIGH_GAIN)
-    c = MeanWaveFormsHighLowGain(LOW_GAIN)
-    d = MeanCameraDisplayHighLowGain(HIGH_GAIN)
-    e = MeanCameraDisplayHighLowGain(LOW_GAIN)
-    f = ChargeIntegrationHighLowGain(HIGH_GAIN)
-    g = ChargeIntegrationHighLowGain(LOW_GAIN)
-    h = CameraMonitoring(HIGH_GAIN)
-    i = PixelParticipationHighLowGain(HIGH_GAIN)
-    j = PixelParticipationHighLowGain(LOW_GAIN)
-    k = PixelTimelineHighLowGain(HIGH_GAIN)
-    ll = PixelTimelineHighLowGain(LOW_GAIN)
+    ########################################################################################
+    processors = [
+        TriggerStatistics(HIGH_GAIN),
+        MeanWaveFormsHighLowGain(HIGH_GAIN),
+        MeanWaveFormsHighLowGain(LOW_GAIN),
+        MeanCameraDisplayHighLowGain(HIGH_GAIN),
+        MeanCameraDisplayHighLowGain(LOW_GAIN),
+        ChargeIntegrationHighLowGain(HIGH_GAIN),
+        ChargeIntegrationHighLowGain(LOW_GAIN),
+        CameraMonitoring(HIGH_GAIN),
+        PixelParticipationHighLowGain(HIGH_GAIN),
+        PixelParticipationHighLowGain(LOW_GAIN),
+        PixelTimelineHighLowGain(HIGH_GAIN),
+        PixelTimelineHighLowGain(LOW_GAIN),
+    ]
 
-    processors = list()
-
-    processors.append(a)
-    processors.append(b)
-    processors.append(c)
-    processors.append(d)
-    processors.append(e)
-    processors.append(f)
-    processors.append(g)
-    processors.append(h)
-    processors.append(i)
-    processors.append(j)
-    processors.append(k)
-    processors.append(ll)
-
+    # LIST OF DICT RESULTS
     NESTED_DICT = {}  # The final results dictionary
 
     NESTED_DICT_KEYS = [
@@ -196,8 +182,6 @@ def main():
         "Results_PixelTimeline_HighGain",
         "Results_PixelTimeline_LowGain",
     ]
-
-    # NESTED_DICT_KEYS = ["Results_PixelParticipation_HighGain"]
 
     # START
     for p in processors:
@@ -257,7 +241,7 @@ def main():
                 plt.close()
 
     end = time.time()
-    print("Processing time:", end - start)
+    print(f"Processing time: {end-start:.2f} s.")
 
     # TODO
     # Reduce code by using loops: for figs and results

--- a/src/nectarchain/dqm/start_dqm.py
+++ b/src/nectarchain/dqm/start_dqm.py
@@ -149,7 +149,7 @@ def main():
     ResPath = f"{output_path}/output/{ChildrenFolderName}/{name}"
 
     # LIST OF PROCESSES TO RUN
-    ########################################################################################
+    ####################################################################################
     processors = [
         TriggerStatistics(HIGH_GAIN),
         MeanWaveFormsHighLowGain(HIGH_GAIN),

--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -90,22 +90,18 @@ class TriggerStatistics(DQMSummary):
 
     def GetResults(self):
         self.TriggerStat_Results_Dict["TRIGGER-TYPES"] = self.triggers
-        self.TriggerStat_Results_Dict[
-            "TRIGGER-STATISTICS"
-        ] = "All: %s, Physical: %s, Pedestals: %s, Others: %s, Wrong times: %s" % (
-            len(self.event_times),
-            len(self.event_phy_times),
-            len(self.event_ped_times),
-            len(self.event_other_times),
-            len(self.event_wrong_times),
-        )
-        self.TriggerStat_Results_Dict[
-            "START-TIMES"
-        ] = "Run start time: %s, First event: %s, Last event: %s" % (
-            self.run_start1,
-            self.run_start,
-            self.run_end,
-        )
+        self.TriggerStat_Results_Dict["TRIGGER-STATISTICS"] = {
+            "All": [len(self.event_times)],
+            "Physical": [len(self.event_phy_times)],
+            "Pedestals": [len(self.event_ped_times)],
+            "Others": [len(self.event_other_times)],
+            "Wrong times": [len(self.event_wrong_times)],
+        }
+        self.TriggerStat_Results_Dict["START-TIMES"] = {
+            "Run start time": self.run_start1,
+            "First event": self.run_start,
+            "Last event": self.run_end,
+        }
         return self.TriggerStat_Results_Dict
 
     def PlotResults(self, name, FigPath):

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -49,6 +49,6 @@ for h in range(1, len(hdu)):
         keyname = hdu[extname].header[f"TTYPE{i+1}"]
         outdict[extname][keyname] = hdu[extname].data[keyname]
 
-db = DQMDB()
-db.insert("test", outdict)
+db = DQMDB(read_only=False)
+db.insert(f"test run {run}", outdict)
 db.commit_and_close()

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -19,7 +19,6 @@ outdict = dict()
 
 for h in range(1, len(hdu)):
     extname = hdu[h].header["EXTNAME"]
-    # Get all camera related fino
     outdict[extname] = dict()
     for i in range(hdu[extname].header["TFIELDS"]):
         keyname = hdu[extname].header[f"TTYPE{i+1}"]

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -4,6 +4,7 @@ The idea is to parse a DQM FITS, in order to feed the ZODB locally from our Boke
 """
 
 import os
+import tarfile
 
 from astropy.io import fits
 from DIRAC.Interfaces.API.Dirac import Dirac
@@ -11,20 +12,30 @@ from ZODB import DB
 
 from nectarchain.dqm.db_utils import DQMDB
 
-dirac = Dirac()
-
 # example = "/tmp/jlenain/scratch/NectarCAM_DQM_Run4971/output/NectarCAM_Run4971
 # /NectarCAM_Run4971_calib/NectarCAM_Run4971_Results.fits"
-example = "/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm/NectarCAM_DQM_Run4971.tar.gz"
+run = 4971
+arch = f"/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm/NectarCAM_DQM_Run{run}.tar.gz"
 
 if not os.path.exists(os.path.basename(lfn)):
+    dirac = Dirac()
+
     dirac.getFile(
         lfn=lfn,
         destDir=f".",
         printOutput=True,
     )
 
-hdu = fits.open(example)
+with tarfile.open(arch, "r") as tar:
+    tar.extractall(".")
+
+fits_file = (
+    f"./NectarCAM_DQM_Run"
+    f"{run}/output/NectarCAM_Run{run}/NectarCAM_Run"
+    f"{run}_calib/NectarCAM_Run{run}_Results.fits"
+)
+
+hdu = fits.open(fits_file)
 
 # Explore FITS file structure
 hdu.info()

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -3,12 +3,26 @@
 The idea is to parse a DQM FITS, in order to feed the ZODB locally from our Bokeh VM, once the DQM has run on DIRAC
 """
 
+import os
+
 from astropy.io import fits
+from DIRAC.Interfaces.API.Dirac import Dirac
 from ZODB import DB
 
 from nectarchain.dqm.db_utils import DQMDB
 
-example = "/tmp/jlenain/scratch/NectarCAM_DQM_Run4971/output/NectarCAM_Run4971/NectarCAM_Run4971_calib/NectarCAM_Run4971_Results.fits"
+dirac = Dirac()
+
+# example = "/tmp/jlenain/scratch/NectarCAM_DQM_Run4971/output/NectarCAM_Run4971
+# /NectarCAM_Run4971_calib/NectarCAM_Run4971_Results.fits"
+example = "/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm/NectarCAM_DQM_Run4971.tar.gz"
+
+if not os.path.exists(os.path.basename(lfn)):
+    dirac.getFile(
+        lfn=lfn,
+        destDir=f".",
+        printOutput=True,
+    )
 
 hdu = fits.open(example)
 

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -7,9 +7,12 @@ VM, once the DQM has run on DIRAC
 import argparse
 import logging
 import os
+import shutil
 import sys
 import tarfile
+from pathlib import Path
 
+import ZEO
 from astropy.io import fits
 from DIRAC.Interfaces.API.Dirac import Dirac
 
@@ -57,11 +60,7 @@ if not os.path.exists(os.path.basename(lfn)):
 with tarfile.open(os.path.basename(lfn), "r") as tar:
     tar.extractall(".")
 
-fits_file = (
-    f"./NectarCAM_DQM_Run"
-    f"{args.run}/output/NectarCAM_Run{args.run}/NectarCAM_Run"
-    f"{args.run}_calib/NectarCAM_Run{args.run}_Results.fits"
-)
+fits_file = f"./NectarCAM_DQM_Run{args.run}/output/NectarCAM_Run{args.run}/NectarCAM_Run{args.run}_calib/NectarCAM_Run{args.run}_Results.fits"
 
 hdu = fits.open(fits_file)
 
@@ -77,6 +76,21 @@ for h in range(1, len(hdu)):
         keyname = hdu[extname].header[f"TTYPE{i+1}"]
         outdict[extname][keyname] = hdu[extname].data[keyname]
 
-db = DQMDB(read_only=False)
-db.insert(f"NectarCAM_Run{args.run}", outdict)
-db.commit_and_close()
+try:
+    db = DQMDB(read_only=False)
+    db.insert(f"NectarCAM_Run{args.run}", outdict)
+    db.commit_and_close()
+except ZEO.Exceptions.ClientDisconnected as e:
+    logger.critical(f"Impossible to feed the ZODB data base. Received error: {e}")
+
+# Remove DQM archive file and directory
+try:
+    os.remove(f"NectarCAM_DQM_Run{args.run}.tar.gz")
+except OSError:
+    logger.warning(
+        f"Could not remove NectarCAM_DQM_Run{args.run}.tar.gz or it does not exist"
+    )
+
+dirpath = Path(f"./NectarCAM_DQM_Run{args.run}")
+if dirpath.exists() and dirpath.is_dir():
+    shutil.rmtree(dirpath)

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Option and argument parser
 parser = argparse.ArgumentParser(
-    description="Fetch a DQM output on DIRAC, parse it " "and feed ZODB",
+    description="Fetch a DQM output on DIRAC, parse it and feed ZODB",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 parser.add_argument(

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -12,6 +12,7 @@ import sys
 import tarfile
 from pathlib import Path
 
+import DIRAC
 import ZEO
 from astropy.io import fits
 from DIRAC.Interfaces.API.Dirac import Dirac
@@ -49,6 +50,8 @@ if args.run is None:
 lfn = f"{args.path}/NectarCAM_DQM_Run{args.run}.tar.gz"
 
 if not os.path.exists(os.path.basename(lfn)):
+    DIRAC.initialize()
+
     dirac = Dirac()
 
     dirac.getFile(

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -60,7 +60,10 @@ if not os.path.exists(os.path.basename(lfn)):
 with tarfile.open(os.path.basename(lfn), "r") as tar:
     tar.extractall(".")
 
-fits_file = f"./NectarCAM_DQM_Run{args.run}/output/NectarCAM_Run{args.run}/NectarCAM_Run{args.run}_calib/NectarCAM_Run{args.run}_Results.fits"
+fits_file = (
+    f"./NectarCAM_DQM_Run{args.run}/output/NectarCAM_Run{args.run}/"
+    f"NectarCAM_Run{args.run}_calib/NectarCAM_Run{args.run}_Results.fits"
+)
 
 hdu = fits.open(fits_file)
 

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -15,7 +15,7 @@ from nectarchain.dqm.db_utils import DQMDB
 # example = "/tmp/jlenain/scratch/NectarCAM_DQM_Run4971/output/NectarCAM_Run4971
 # /NectarCAM_Run4971_calib/NectarCAM_Run4971_Results.fits"
 run = 4971
-arch = f"/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm/NectarCAM_DQM_Run{run}.tar.gz"
+lfn = f"/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm/NectarCAM_DQM_Run{run}.tar.gz"
 
 if not os.path.exists(os.path.basename(lfn)):
     dirac = Dirac()
@@ -26,7 +26,7 @@ if not os.path.exists(os.path.basename(lfn)):
         printOutput=True,
     )
 
-with tarfile.open(arch, "r") as tar:
+with tarfile.open(os.path.basename(lfn), "r") as tar:
     tar.extractall(".")
 
 fits_file = (

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -1,0 +1,30 @@
+"""Parse a DQM FITS file as nested dictionary
+
+The idea is to parse a DQM FITS, in order to feed the ZODB locally from our Bokeh VM, once the DQM has run on DIRAC
+"""
+
+from astropy.io import fits
+from ZODB import DB
+
+from nectarchain.dqm.db_utils import DQMDB
+
+example = "/tmp/jlenain/scratch/NectarCAM_DQM_Run4971/output/NectarCAM_Run4971/NectarCAM_Run4971_calib/NectarCAM_Run4971_Results.fits"
+
+hdu = fits.open(example)
+
+# Explore FITS file structure
+hdu.info()
+
+outdict = dict()
+
+for h in range(1, len(hdu)):
+    extname = hdu[h].header["EXTNAME"]
+    # Get all camera related fino
+    outdict[extname] = dict()
+    for i in range(hdu[extname].header["TFIELDS"]):
+        keyname = hdu[extname].header[f"TTYPE{i+1}"]
+        outdict[extname][keyname] = hdu[extname].data[keyname]
+
+db = DQMDB()
+db.insert("test", outdict)
+db.commit_and_close()


### PR DESCRIPTION
This PR introduces a new format for the DQM output in FITS files, as well as a user script which, once a DQM analysis has been run on DIRAC, grabs the results from DIRAC, extracts the archive and ingests the results in the ZODB data base.

This is a fundamental brick towards an automatic pipeline which would launch the DQM systematically on DIRAC on data transfer from CEA to DIRAC, and results ingestion in ZODB.

This was tested to run fine locally (see http://lpnhe-cta2.in2p3.fr/nectarcam-dqm), but we need to merge this PR, to trigger the building of an Apptainer image in CI, which would then be used to launch a couple of DQM jobs on DIRAC, to be able to further test the user script from start to finish.

In case of issues along the way, another PR will be opened.