### PR TITLE
Automatic DQM jobs on DIRAC

### DIFF
--- a/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
+++ b/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
@@ -11,6 +11,12 @@ exec 1>"$LOGFILE" 2>&1
 . "/opt/conda/etc/profile.d/conda.sh"
 conda activate nectar-dev
 
+# Initialize DIRAC proxy from user certificate:
+if ! dirac-proxy-init -M -g cta_nectarcam --pwstdin < ~/.dirac.pwd; then
+    echo "DIRAC proxy initialization failed..."
+    exit 1
+fi
+
 remoteParentDir="/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm"
 nectarchainScriptDir="/opt/cta/nectarchain/src/nectarchain/user_scripts/jlenain"
 

--- a/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
+++ b/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
@@ -5,6 +5,7 @@
 
 # Log everything to $LOGFILE
 LOGFILE=${0%".sh"}_$(date +%F).log
+LOGFILE=$HOME/log/$(basename $LOGFILE)
 exec 1>"$LOGFILE" 2>&1
 
 . "/opt/conda/etc/profile.d/conda.sh"

--- a/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
+++ b/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
@@ -10,6 +10,7 @@ exec 1>"$LOGFILE" 2>&1
 . "/opt/conda/etc/profile.d/conda.sh"
 conda activate nectar-dev
 
-for run in $(dls "/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm" | grep -ve "/vo.cta" | awk -F. '{print $1}' | awk -Fn '{print $2}'); do
-    python /opt/cta/nectarchain/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py -r $run
-done
+remoteParentDir="/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm"
+nectarchainScriptDir="/opt/cta/nectarchain/src/nectarchain/user_scripts/jlenain"
+
+python ${nectarchainScriptDir}/parse_dqm_fits_file.py -r $(dls ${remoteParentDir} | grep -ve "/vo.cta" | awk -F. '{print $1}' | awk -Fn '{print $2}' | tr '\n' ' ')

--- a/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
+++ b/src/nectarchain/user_scripts/jlenain/cronjob_parse_dqm_fits_file.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# -*- coding: utf-8 -*-
+#
+# This script is to be used as a cronjob on the nectarcam-dqm-rw VM on the LPNHE OpenStack cloud platform, in order to feed the ZODB database from DQM run on DIRAC.
+
+# Log everything to $LOGFILE
+LOGFILE=${0%".sh"}_$(date +%F).log
+exec 1>"$LOGFILE" 2>&1
+
+. "/opt/conda/etc/profile.d/conda.sh"
+conda activate nectar-dev
+
+for run in $(dls "/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm" | grep -ve "/vo.cta" | awk -F. '{print $1}' | awk -Fn '{print $2}'); do
+    python /opt/cta/nectarchain/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py -r $run
+done

--- a/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
+++ b/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# -*- coding: utf-8 -*-
+#
+# Author: Jean-Philippe Lenain <jlenain@in2p3.fr>
+#
+# Script as a cronjob to dynamically launch NectarCAM DQM runs on DIRAC after data transfer, to be run once a day on sedipccaa23 in CEA/Irfu.
+
+# Log everything to $LOGFILE
+LOGFILE=${0%".sh"}_$(date +%F).log
+exec 1>"$LOGFILE" 2>&1
+
+localParentDir="/data/nvme/ZFITS"
+remoteParentDir="/vo.cta.in2p3.fr/nectarcam"
+nectarchainScriptDir="$HOME/local/src/python/cta-observatory/nectarchain/src/nectarchain/user_scripts/jlenain/dqm_job_submitter"
+
+cd $nectarchainScriptDir
+
+for run in $(find ${localParentDir} -type f -name "NectarCAM*.fits.fz" | awk -F. '{print $2}' | awk -Fn '{print $2}' | sort | uniq); do
+    echo "Probing files for run ${run}"
+    nbLocalFiles=$(find ${localParentDir} -type f -name "NectarCAM.Run${run}.????.fits.fz" | wc -l)
+    echo "  Found $nbLocalFiles local files for run $run"
+    nbRemoteFiles=$(dfind $remoteParentDir | grep -e "NectarCAM.Run${run}" | grep -e "fits.fz" | wc -l)
+    echo "  Found $nbRemoteFiles remote files on DIRAC for run $run"
+    # If number of local and remote files matching, will attempt to launch a DQM run
+    if [ $nbLocalFiles -eq $nbRemoteFiles ]; then
+        echo "  Run $run: number of local and remote files matching, will attempt to submit a DQM job"
+        yyyymmdd=$(find ${localParentDir} -type f -name "NectarCAM.Run${run}.????.fits.fz" | head -n 1 | awk -F/ '{print $6}')
+        yyyy=${yyyymmdd:0:4}
+        mm=${yyyymmdd:4:2}
+        dd=${yyyymmdd:6:2}
+        cmd="python submit_dqm_processor.py -d "${yyyy}-${mm}-${dd}" -r $run"
+	echo "Running: $cmd"
+	eval $cmd
+    else
+	echo "  Run $run is not yet complete on DIRAC, will wait another day before launching a DQM job on it."
+    fi
+done

--- a/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
+++ b/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
@@ -7,6 +7,7 @@
 
 # Log everything to $LOGFILE
 LOGFILE=${0%".sh"}_$(date +%F).log
+LOGFILE=$HOME/log/$(basename $LOGFILE)
 exec 1>"$LOGFILE" 2>&1
 
 source /opt/cta/mambaforge/etc/profile.d/conda.sh

--- a/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
+++ b/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
@@ -9,6 +9,9 @@
 LOGFILE=${0%".sh"}_$(date +%F).log
 exec 1>"$LOGFILE" 2>&1
 
+source /opt/cta/mambaforge/etc/profile.d/conda.sh
+conda activate ctadirac
+
 localParentDir="/data/nvme/ZFITS"
 remoteParentDir="/vo.cta.in2p3.fr/nectarcam"
 nectarchainScriptDir="$HOME/local/src/python/cta-observatory/nectarchain/src/nectarchain/user_scripts/jlenain/dqm_job_submitter"
@@ -37,6 +40,6 @@ for run in $(find ${localParentDir} -type f -name "NectarCAM*.fits.fz" | awk -F.
             echo "  DQM job for run $run already submitted, either ongoing or failed, skipping it."
         fi
     else
-	      echo "  Run $run is not yet complete on DIRAC, will wait another day before launching a DQM job on it."
+        echo "  Run $run is not yet complete on DIRAC, will wait another day before launching a DQM job on it."
     fi
 done

--- a/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
+++ b/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
@@ -24,14 +24,19 @@ for run in $(find ${localParentDir} -type f -name "NectarCAM*.fits.fz" | awk -F.
     # If number of local and remote files matching, will attempt to launch a DQM run
     if [ $nbLocalFiles -eq $nbRemoteFiles ]; then
         echo "  Run $run: number of local and remote files matching, will attempt to submit a DQM job"
-        yyyymmdd=$(find ${localParentDir} -type f -name "NectarCAM.Run${run}.????.fits.fz" | head -n 1 | awk -F/ '{print $6}')
-        yyyy=${yyyymmdd:0:4}
-        mm=${yyyymmdd:4:2}
-        dd=${yyyymmdd:6:2}
-        cmd="python submit_dqm_processor.py -d "${yyyy}-${mm}-${dd}" -r $run"
-	echo "Running: $cmd"
-	eval $cmd
+        # Has this DQM run already been submitted ?
+        if [ $(dstat | grep -e "NectarCAM DQM run ${run}" | wc -l) -eq 0 ]; then
+            yyyymmdd=$(find ${localParentDir} -type f -name "NectarCAM.Run${run}.????.fits.fz" | head -n 1 | awk -F/ '{print $6}')
+            yyyy=${yyyymmdd:0:4}
+            mm=${yyyymmdd:4:2}
+            dd=${yyyymmdd:6:2}
+            cmd="python submit_dqm_processor.py -d "${yyyy}-${mm}-${dd}" -r $run"
+            echo "Running: $cmd"
+            eval $cmd
+        else
+            echo "  DQM job for run $run already submitted, either ongoing or failed, skipping it."
+        fi
     else
-	echo "  Run $run is not yet complete on DIRAC, will wait another day before launching a DQM job on it."
+	      echo "  Run $run is not yet complete on DIRAC, will wait another day before launching a DQM job on it."
     fi
 done

--- a/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
+++ b/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/cronjob_launchDQM.sh
@@ -16,19 +16,19 @@ localParentDir="/data/nvme/ZFITS"
 remoteParentDir="/vo.cta.in2p3.fr/nectarcam"
 nectarchainScriptDir="$HOME/local/src/python/cta-observatory/nectarchain/src/nectarchain/user_scripts/jlenain/dqm_job_submitter"
 
-cd $nectarchainScriptDir
+cd $nectarchainScriptDir || (echo "Failed to cd into ${nectarchainScriptDir}, exiting..."; exit 1)
 
 for run in $(find ${localParentDir} -type f -name "NectarCAM*.fits.fz" | awk -F. '{print $2}' | awk -Fn '{print $2}' | sort | uniq); do
     echo "Probing files for run ${run}"
     nbLocalFiles=$(find ${localParentDir} -type f -name "NectarCAM.Run${run}.????.fits.fz" | wc -l)
     echo "  Found $nbLocalFiles local files for run $run"
-    nbRemoteFiles=$(dfind $remoteParentDir | grep -e "NectarCAM.Run${run}" | grep -e "fits.fz" | wc -l)
+    nbRemoteFiles=$(dfind ${remoteParentDir} | grep -e "NectarCAM.Run${run}" | grep --count -e "fits.fz")
     echo "  Found $nbRemoteFiles remote files on DIRAC for run $run"
     # If number of local and remote files matching, will attempt to launch a DQM run
-    if [ $nbLocalFiles -eq $nbRemoteFiles ]; then
+    if [ ${nbLocalFiles} -eq ${nbRemoteFiles} ]; then
         echo "  Run $run: number of local and remote files matching, will attempt to submit a DQM job"
         # Has this DQM run already been submitted ?
-        if [ $(dstat | grep -e "NectarCAM DQM run ${run}" | wc -l) -eq 0 ]; then
+        if [ $(dstat | grep --count -e "NectarCAM DQM run ${run}") -eq 0 ]; then
             yyyymmdd=$(find ${localParentDir} -type f -name "NectarCAM.Run${run}.????.fits.fz" | head -n 1 | awk -F/ '{print $6}')
             yyyy=${yyyymmdd:0:4}
             mm=${yyyymmdd:4:2}

--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -35,6 +35,13 @@ parser.add_argument(
     type=str,
 )
 parser.add_argument(
+    "-f",
+    "--force",
+    default=False,
+    action="store_true",
+    help="if this run is already in the DB, force re-parsing its DQM output again.",
+)
+parser.add_argument(
     "-p",
     "--path",
     default="/vo.cta.in2p3.fr/user/j/jlenain/nectarcam/dqm",
@@ -46,6 +53,14 @@ args = parser.parse_args()
 if args.run is None:
     logger.critical("A run number should be provided.")
     sys.exit(1)
+
+db = DQMDB(read_only=True)
+if not args.force and f"NectarCAM_Run{args.run}" in list(db.root.keys()):
+    logger.warning(
+        f'The run {args.run} is already present in the DB, will not parse this DQM run, or consider forcing it with the "--force" option.'
+    )
+    sys.exit(0)
+del db
 
 lfn = f"{args.path}/NectarCAM_DQM_Run{args.run}.tar.gz"
 


### PR DESCRIPTION
This PR adds a script to be used as cronjob to automatically submit DQM jobs on DIRAC once a run has been transferred from CEA to DIRAC.

This script is already in production from now on at CEA/Irfu.