### PR TITLE
Reverse order of run list in Bokeh

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -59,7 +59,7 @@ def update_camera_displays(attr, old, new):
 print("Opening connection to ZODB")
 db = DQMDB(read_only=True).root
 print("Getting list of run numbers")
-runids = sorted(list(db.keys()))
+runids = sorted(list(db.keys()), reverse=True)
 
 # First, get the run id with the most populated result dictionary
 # On the full DB, this takes an awful lot of time, and saturates the RAM on the host


### PR DESCRIPTION
At @dkerszberg 's request, this PR reverse the order of the list of runs displayed in the DQM Bokeh app (last run listed first).