### PR TITLE
Dqm update - using standard ctapipe tools

### DIFF
--- a/src/nectarchain/dqm/camera_monitoring.py
+++ b/src/nectarchain/dqm/camera_monitoring.py
@@ -39,7 +39,7 @@ class CameraMonitoring(DQMSummary):
         self.ChargeInt_Figures_Dict = {}
         self.ChargeInt_Figures_Names_Dict = {}
 
-    def ConfigureForRun(self, path, Pix, Samp, Reader1):
+    def ConfigureForRun(self, path, Pix, Samp, Reader1, charges_kwargs):
         # define number of pixels and samples
         self.Pix = Pix
         self.Samp = Samp

--- a/src/nectarchain/dqm/mean_camera_display.py
+++ b/src/nectarchain/dqm/mean_camera_display.py
@@ -31,7 +31,7 @@ class MeanCameraDisplayHighLowGain(DQMSummary):
         self.MeanCameraDisplay_Figures_Dict = {}
         self.MeanCameraDisplay_Figures_Names_Dict = {}
 
-    def ConfigureForRun(self, path, Pix, Samp, Reader1):
+    def ConfigureForRun(self, path, Pix, Samp, Reader1, charges_kwargs):
         # define number of pixels and samples
         self.Pix = Pix
         self.Samp = Samp

--- a/src/nectarchain/dqm/mean_waveforms.py
+++ b/src/nectarchain/dqm/mean_waveforms.py
@@ -23,7 +23,7 @@ class MeanWaveFormsHighLowGain(DQMSummary):
         self.MeanWaveForms_Figures_Dict = {}
         self.MeanWaveForms_Figures_Names_Dict = {}
 
-    def ConfigureForRun(self, path, Pix, Samp, Reader1):
+    def ConfigureForRun(self, path, Pix, Samp, Reader1, charges_kwargs):
         # define number of pixels and samples
         self.Pix = Pix
         self.Samp = Samp

--- a/src/nectarchain/dqm/pixel_participation.py
+++ b/src/nectarchain/dqm/pixel_participation.py
@@ -25,7 +25,7 @@ class PixelParticipationHighLowGain(DQMSummary):
         self.PixelParticipation_Figures_Dict = {}
         self.PixelParticipation_Figures_Names_Dict = {}
 
-    def ConfigureForRun(self, path, Pix, Samp, Reader1):
+    def ConfigureForRun(self, path, Pix, Samp, Reader1, charges_kwargs):
         # define number of pixels and samples
         self.Pix = Pix
         self.Samp = Samp

--- a/src/nectarchain/dqm/pixel_timeline.py
+++ b/src/nectarchain/dqm/pixel_timeline.py
@@ -24,7 +24,7 @@ class PixelTimelineHighLowGain(DQMSummary):
         self.PixelTimeline_Figures_Dict = {}
         self.PixelTimeline_Figures_Names_Dict = {}
 
-    def ConfigureForRun(self, path, Pix, Samp, Reader1):
+    def ConfigureForRun(self, path, Pix, Samp, Reader1, charges_kwargs):
         # define number of pixels and samples
         self.Pix = Pix
         self.Samp = Samp

--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -32,7 +32,7 @@ class TriggerStatistics(DQMSummary):
         self.TriggerStat_Figures_Dict = {}
         self.TriggerStat_Figures_Names_Dict = {}
 
-    def ConfigureForRun(self, path, Pix, Samp, Reader1):
+    def ConfigureForRun(self, path, Pix, Samp, Reader1, charges_kwargs):
         # define number of pixels and samples
         self.Pix = Pix
         self.Samp = Samp


### PR DESCRIPTION
In chargeIntegration:
Line 108 - 117
The way Broken Pixles is computed does not hide the 21 pixels hidden by the camera shutter. In the display the values are still there.
 Alternatively using self.pixelBAD = evt.mon.tel[0].pixel_status.hardware_failing_pixels breaks the code at line 129 or 139