### PR TITLE
Use secrets to upload reports to Codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ name: CI
 on:
   workflow_dispatch:
   push:
-  # TODO
-  # Remove comment: just a test to force CI on push
-  # branches:
-  #   - main
-  # tags:
-  #   - '**'
+  branches:
+    - main
+  tags:
+    - '**'
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ name: CI
 on:
   workflow_dispatch:
   push:
-  branches:
-    - main
-  tags:
-    - '**'
+  # TODO
+  # Remove comment: just a test to force CI on push
+  # branches:
+  #   - main
+  # tags:
+  #   - '**'
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,10 @@ jobs:
         run: |
           pytest -n auto --dist loadscope --cov=nectarchain --cov-report=xml --ignore=src/nectarchain/user_scripts
 
-      - uses: codecov/codecov-action@v5
+      - name: Upload coverage reports to Codecov with GitHub Action
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 
   docs:


### PR DESCRIPTION
Coverage is not accurate in the repo badge and the [codecov.io dashboard](https://app.codecov.io/gh/cta-observatory/nectarchain), where the last visible commit dates from 10 months ago. This PR attempts to fix it.