### PR TITLE
Fixing API documentation for ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,6 +143,7 @@ html_context = {
     "github_repo": f"{project}",
     "github_version": "main",
     "doc_path": "docs",
+    "READTHEDOCS": True,
 }
 html_file_suffix = ".html"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,8 @@ copyright = "{}.  Last updated {}".format(
 )
 python_requires = pyproject["project"]["requires-python"]
 
+sys.path.insert(0, os.path.abspath(f"../src/{project}"))
+
 # make some variables available to each page
 rst_epilog = f"""
 .. |python_requires| replace:: {python_requires}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,8 +27,6 @@ copyright = "{}.  Last updated {}".format(
 )
 python_requires = pyproject["project"]["requires-python"]
 
-# sys.path.insert(0, os.path.abspath(f"../src/{project}"))
-
 # make some variables available to each page
 rst_epilog = f"""
 .. |python_requires| replace:: {python_requires}
@@ -85,11 +83,10 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_mock_imports = [
-    # f"{project}.makers.calibration.core",
-    # f"{project}.makers.extractor.charge_extractor",
+    f"{project}.makers.extractor.charge_extractor",
     f"{project}.dqm.bokeh_app",
-    "matplotlib",
     "iminuit",
+    "matplotlib",
 ]
 
 # intersphinx allows referencing other packages sphinx docs
@@ -147,7 +144,6 @@ html_context = {
     "github_repo": f"{project}",
     "github_version": "main",
     "doc_path": "docs",
-    # "READTHEDOCS": True,
 }
 html_file_suffix = ".html"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = "{}.  Last updated {}".format(
 )
 python_requires = pyproject["project"]["requires-python"]
 
-sys.path.insert(0, os.path.abspath(f"../src/{project}"))
+# sys.path.insert(0, os.path.abspath(f"../src/{project}"))
 
 # make some variables available to each page
 rst_epilog = f"""
@@ -85,8 +85,8 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_mock_imports = [
-    f"{project}.makers.calibration.core",
-    f"{project}.makers.extractor.charge_extractor",
+    # f"{project}.makers.calibration.core",
+    # f"{project}.makers.extractor.charge_extractor",
     f"{project}.dqm.bokeh_app",
     "matplotlib",
     "iminuit",
@@ -147,7 +147,7 @@ html_context = {
     "github_repo": f"{project}",
     "github_version": "main",
     "doc_path": "docs",
-    "READTHEDOCS": True,
+    # "READTHEDOCS": True,
 }
 html_file_suffix = ".html"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,8 @@ autodoc_mock_imports = [
     f"{project}.makers.calibration.core",
     f"{project}.makers.extractor.charge_extractor",
     f"{project}.dqm.bokeh_app",
+    "matplotlib",
+    "iminuit",
 ]
 
 # intersphinx allows referencing other packages sphinx docs


### PR DESCRIPTION
This PR fixes the build of the API documentation on ReadTheDocs, which was incomplete (only 2 modules listed - `tools` and `version`) since November 2024. This all boiled down to include additional mock imports.