### PR TITLE
Fix deployment on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,68 +1,83 @@
-================================================
-nectarchain |pypi| |conda| |ci| |doc| |codecov|
-================================================
+=========================================================================
+nectarchain |pypi| |conda| |Test Status| |Documentation Status| |codecov|
+=========================================================================
 
-.. |ci| image:: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml/badge.svg?branch=main
-    :target: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amain
-    :alt: Test Status
-.. |pypi| image:: https://badge.fury.io/py/nectarchain.svg
-    :target: https://pypi.org/project/nectarchain
-.. |conda| image:: https://anaconda.org/conda-forge/nectarchain/badges/version.svg
-    :target: https://anaconda.org/conda-forge/nectarchain
-.. |codecov| image:: https://codecov.io/github/cta-observatory/nectarchain/graph/badge.svg?token=TDhZlJtbMv
-    :target: https://codecov.io/github/cta-observatory/nectarchain
-.. |doc| image:: https://readthedocs.org/projects/nectarchain/badge/?version=latest
-    :target: https://nectarchain.readthedocs.io/en/latest/?badge=latest
-    :alt: Documentation Status
 
-Repository for the high level analysis of the NectarCAM data, a camera to equip the
-medium-sized telescopes of `CTAO <https://www.ctao.org/>`_ in its Northern site.
-The analysis is heavily based on `ctapipe <https://github.com/cta-observatory/ctapipe>`_,
-adding custom code for NectarCAM calibration.
+Repository for the high level analysis of the NectarCAM data, a camera
+to equip the medium-sized telescopes of `CTAO <https://www.ctao.org/>`__
+in its Northern site. The analysis is heavily based on
+`ctapipe <https://github.com/cta-observatory/ctapipe>`__, adding custom
+code for NectarCAM calibration.
 
 ``nectarchain`` is currently pinned to ``ctapipe`` version 0.19.
 
-This code is under rapid development. It is not recommended for production use unless you are an expert or developer!
+This code is under rapid development. It is not recommended for
+production use unless you are an expert or developer!
 
-* Code: https://github.com/cta-observatory/nectarchain
-* Docs: https://nectarchain.readthedocs.io/
+- Code: https://github.com/cta-observatory/nectarchain
+- Docs: https://nectarchain.readthedocs.io/
 
 Installation for Users
 ======================
 
-``nectarchain`` and its dependencies may be installed using the *Anaconda* or
-*Miniconda* package system. We recommend creating a conda virtual environment
-first, to isolate the installed version and dependencies from your main
-environment (this is optional).
+``nectarchain`` and its dependencies may be installed using the
+*Anaconda* or *Miniconda* package system. We recommend creating a conda
+virtual environment first, to isolate the installed version and
+dependencies from your main environment (this is optional).
 
-The latest version of ``nectarchain`` can be installed via::
+The latest version of ``nectarchain`` can be installed via:
 
-  mamba install -c conda-forge nectarchain
+::
 
-or via::
+   mamba install -c conda-forge nectarchain
 
-  pip install nectarchain
+or via:
 
-**Note**: to install a specific version of ``nectarchain``, take look at the documentation `here <https://nectarchain.readthedocs.io/en/latest/user-guide/index.html>`_.
+::
 
-**Note**: ``mamba`` is a C++ reimplementation of conda and can be found `here <https://github.com/mamba-org/mamba>`_.
+   pip install nectarchain
 
-Note this is *pre-alpha* software and is not yet stable enough for end-users (expect large API changes until the first stable 1.0 release).
+**Note**: to install a specific version of ``nectarchain``, take look at
+the documentation
+`here <https://nectarchain.readthedocs.io/en/latest/user-guide/index.html>`__.
 
-Developers should follow the development install instructions found in the
-`documentation <https://nectarchain.readthedocs.io/en/latest/developer-guide/index.html>`_.
+**Note**: ``mamba`` is a C++ reimplementation of conda and can be found
+`here <https://github.com/mamba-org/mamba>`__.
 
+Note this is *pre-alpha* software and is not yet stable enough for
+end-users (expect large API changes until the first stable 1.0 release).
+
+Developers should follow the development install instructions found in
+the
+`documentation <https://nectarchain.readthedocs.io/en/latest/developer-guide/index.html>`__.
 
 Contributing
 ============
 
 All contribution are welcome.
 
-Guidelines are the same as `ctapipe's ones <https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html>`_.
-See `here <https://ctapipe.readthedocs.io/en/latest/developer-guide/pullrequests.html#pullrequests>`_ how to make a pull request to contribute.
-
+Guidelines are the same as `ctapipe's
+ones <https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html>`__.
+See
+`here <https://ctapipe.readthedocs.io/en/latest/developer-guide/pullrequests.html#pullrequests>`__
+how to make a pull request to contribute.
 
 Report issue / Ask a question
 =============================
 
-Please use `GitHub Issues <https://github.com/cta-observatory/nectarchain/issues>`_ to report issues or `GitHub Discussions <https://github.com/cta-observatory/nectarchain/discussions>`_ for questions and discussions.
+Please use `GitHub
+Issues <https://github.com/cta-observatory/nectarchain/issues>`__ to
+report issues or `GitHub
+Discussions <https://github.com/cta-observatory/nectarchain/discussions>`__
+for questions and discussions.
+
+.. |pypi| image:: https://badge.fury.io/py/nectarchain.svg
+   :target: https://pypi.org/project/nectarchain
+.. |conda| image:: https://anaconda.org/conda-forge/nectarchain/badges/version.svg
+   :target: https://anaconda.org/conda-forge/nectarchain
+.. |Test Status| image:: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml/badge.svg?branch=main
+   :target: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amain
+.. |Documentation Status| image:: https://readthedocs.org/projects/nectarchain/badge/?version=latest
+   :target: https://nectarchain.readthedocs.io/en/latest/?badge=latest
+.. |codecov| image:: https://codecov.io/github/cta-observatory/nectarchain/graph/badge.svg?token=TDhZlJtbMv
+   :target: https://codecov.io/github/cta-observatory/nectarchain

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=========================================================================
-nectarchain |pypi| |conda| |Test Status| |Documentation Status| |codecov|
-=========================================================================
+================================================
+nectarchain |pypi| |conda| |CI| |docs| |codecov|
+================================================
 
 
 Repository for the high level analysis of the NectarCAM data, a camera
@@ -75,9 +75,9 @@ for questions and discussions.
    :target: https://pypi.org/project/nectarchain
 .. |conda| image:: https://anaconda.org/conda-forge/nectarchain/badges/version.svg
    :target: https://anaconda.org/conda-forge/nectarchain
-.. |Test Status| image:: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml/badge.svg?branch=main
+.. |CI| image:: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/cta-observatory/nectarchain/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amain
-.. |Documentation Status| image:: https://readthedocs.org/projects/nectarchain/badge/?version=latest
+.. |docs| image:: https://readthedocs.org/projects/nectarchain/badge/?version=latest
    :target: https://nectarchain.readthedocs.io/en/latest/?badge=latest
 .. |codecov| image:: https://codecov.io/github/cta-observatory/nectarchain/graph/badge.svg?token=TDhZlJtbMv
    :target: https://codecov.io/github/cta-observatory/nectarchain


### PR DESCRIPTION
While trying to issue a new release of `nectarchain`, it appeared that the automatic deployment on PyPI was broken:

https://github.com/cta-observatory/nectarchain/actions/runs/13200381534/job/36850790823

The cryptic error message:
```
Checking dist/nectarchain-0.2.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.
```
was actually pointing to a presumably misformatted `README.rst` file.

This PR should fix this, and re-enable automatic publication on PyPI. This was tested locally with:
```
python -m build
twine check --strict dist/*
```