### PR TITLE
fix tool's logger to properly log exception

### DIFF
--- a/src/nectarchain/makers/calibration/gain/photostat_makers.py
+++ b/src/nectarchain/makers/calibration/gain/photostat_makers.py
@@ -108,7 +108,7 @@ class PhotoStatisticNectarCAMCalibrationTool(GainNectarCAMCalibrationTool):
                 max_events=self.max_events,
             )
         except Exception as e:
-            self.log.warning(e)
+            self.log.warning(f"{e}", exc_info=True)
             FF_files = []
         try:
             Ped_files = DataManagement.find_charges(
@@ -116,7 +116,7 @@ class PhotoStatisticNectarCAMCalibrationTool(GainNectarCAMCalibrationTool):
                 max_events=self.max_events,
             )
         except Exception as e:
-            self.log.warning(e)
+            self.log.warning(f"{e}", exc_info=True)
             Ped_files = []
         if self.reload_events or len(FF_files) != 1 or len(Ped_files) != 1:
             if len(FF_files) != 1 or len(Ped_files) != 1:

--- a/src/nectarchain/makers/core.py
+++ b/src/nectarchain/makers/core.py
@@ -303,7 +303,7 @@ class EventsLoopNectarCAMCalibrationTool(BaseNectarCAMCalibrationTool):
                 )
             )
         except HDF5ExtError as err:
-            self.log.warning(err.args[0], exc_info=True)
+            self.log.warning(f"{err}", exc_info=True)
             self.log.warning("retry with w mode instead of a")
             self.writer = self.enter_context(
                 HDF5TableWriter(
@@ -314,7 +314,7 @@ class EventsLoopNectarCAMCalibrationTool(BaseNectarCAMCalibrationTool):
                 )
             )
         except Exception as err:
-            self.log.error(err, exc_info=True)
+            self.log.error(f"{err}", exc_info=True)
             raise err
 
     def setup(self, *args, **kwargs):
@@ -487,11 +487,10 @@ class EventsLoopNectarCAMCalibrationTool(BaseNectarCAMCalibrationTool):
                     "NectarCAMContainer"
                 )
         except FieldValidationError as e:
-            log.warning(e, exc_info=True)
+            self.log.warning(f"{e}", exc_info=True)
             self.log.warning("the container has not been written")
         except Exception as e:
-            log.error(e, exc_info=True)
-            self.log.error(e.args[0], exc_info=True)
+            self.log.error(f"{e}", exc_info=True)
             raise e
 
     @property


### PR DESCRIPTION
This PR fix the issue https://github.com/cta-observatory/nectarchain/issues/186 when the logger member of `ctapipe` `tools` is used to log an exception. 

Explanation : The `ctapipe` logger within tools has a specific handler which gives error when one use the logger as
`self.logger.info(e) `with e an `Exception`. 