### PR TITLE
Pin ctapipe_io_nectarcam version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.11
   - ctapipe=0.19
-  - ctapipe-io-nectarcam
+  - ctapipe-io-nectarcam=0.1
   - jinja2=3.0.1
   - jupyterlab
   - jupytext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ctapipe~=0.19",
-    "ctapipe-io-nectarcam~=0.1",
+    "ctapipe-io-nectarcam==0.1",
     "pandas",
     "scipy==1.11.4",
     "zodb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ctapipe~=0.19",
-    "ctapipe-io-nectarcam==0.1",
+    "ctapipe-io-nectarcam<0.2",
     "pandas",
     "scipy==1.11.4",
     "zodb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "ctapipe~=0.19",
-    "ctapipe-io-nectarcam",
+    "ctapipe-io-nectarcam~=0.1",
     "pandas",
     "scipy==1.11.4",
     "zodb",


### PR DESCRIPTION
Pin dependency of `ctapipe_io_nectarcam` to version 0.1, to maintain the use of v0.19 of `ctapipe` for the moment.