### PR TITLE
Fix bug in DQM for START-TIMES of unsized type

### DIFF
--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -100,9 +100,9 @@ class TriggerStatistics(DQMSummary):
             "Wrong times": [len(self.event_wrong_times)],
         }
         self.TriggerStat_Results_Dict["START-TIMES"] = {
-            "Run start time": self.run_start1,
-            "First event": self.run_start,
-            "Last event": self.run_end,
+            "Run start time": [self.run_start1],
+            "First event": [self.run_start],
+            "Last event": [self.run_end],
         }
         return self.TriggerStat_Results_Dict
 


### PR DESCRIPTION
The DQM currently has a systematic warning with:

```
2025-07-23 14:08:46,124 [1;33mWARNING[0m [nectarchain.dqm.dqm_summary_processor] (dqm_summary_processor.write_all_results): Caught TypeError, skipping START-TIMES. Details: len() of unsized object
```

This PR addresses this.