### PR TITLE
Fix bug in ChargeDistributionFilter for pedestal maker

### DIFF
--- a/src/nectarchain/makers/component/pedestal_component.py
+++ b/src/nectarchain/makers/component/pedestal_component.py
@@ -499,29 +499,6 @@ class PedestalEstimationComponent(NectarCAMComponent):
         # log.info('JPL: waveformsContainers=',waveformsContainers.containers[
         # EventType.SKY_PEDESTAL].nsamples)
 
-        # If we want to filter based on charges distribution
-        # make sure that the charge distribution container is filled
-        if (
-            self.filter_method == "ChargeDistributionFilter"
-            and self._chargesContainers is None
-        ):
-            log.debug("Compute charges from waveforms")
-            chargesComponent_kwargs = {}
-            chargesComponent_configurable_traits = (
-                ComponentUtils.get_configurable_traits(ChargesComponent)
-            )
-            for key in kwargs.keys():
-                if key in chargesComponent_configurable_traits.keys():
-                    chargesComponent_kwargs[key] = kwargs[key]
-            self._chargesContainers = ChargesComponent.create_from_waveforms(
-                waveformsContainer=self._waveformsContainers,
-                subarray=self.subarray,
-                config=self.config,
-                parent=self.parent,
-                *args,
-                **chargesComponent_kwargs,
-            )
-
         # Check if waveforms container is empty
         if self._waveformsContainers is None:
             log.warning("Waveforms container is none, pedestals cannot be evaluated")
@@ -535,6 +512,29 @@ class PedestalEstimationComponent(NectarCAMComponent):
             # container with no results
             return None
         else:
+            # If we want to filter based on charges distribution
+            # make sure that the charge distribution container is filled
+            if (
+                self.filter_method == "ChargeDistributionFilter"
+                and self._chargesContainers is None
+            ):
+                log.debug("Compute charges from waveforms")
+                chargesComponent_kwargs = {}
+                chargesComponent_configurable_traits = (
+                    ComponentUtils.get_configurable_traits(ChargesComponent)
+                )
+                for key in kwargs.keys():
+                    if key in chargesComponent_configurable_traits.keys():
+                        chargesComponent_kwargs[key] = kwargs[key]
+                self._chargesContainers = ChargesComponent.create_from_waveforms(
+                    waveformsContainer=self._waveformsContainers,
+                    subarray=self.subarray,
+                    config=self.config,
+                    parent=self.parent,
+                    *args,
+                    **chargesComponent_kwargs,
+                )
+
             # Build mask to filter the waveforms
             # Mask based on the high gain channel that is most sensitive to signals
             # Initialize empty mask


### PR DESCRIPTION
While analyzing some data I had a crash. I found out this was due to the fact that a piece of code was misplaced. I moved the piece of code to create a charge container after the check that the waveforms are available. This avoids a crash in some special cases like the one I had encountered.