### PR TITLE
Launch TRR test suite GUI not in full screen

### DIFF
--- a/src/nectarchain/trr_test_suite/gui.py
+++ b/src/nectarchain/trr_test_suite/gui.py
@@ -198,7 +198,8 @@ class TestRunner(QWidget):
         # Set the main layout to the window
         self.setLayout(main_layout)
         self.setWindowTitle("Test Runner GUI")
-        self.showFullScreen()
+        # self.showFullScreen()
+        self.show()
 
     def get_parameters_from_module(self, module):
         # Fetch parameters from the module


### PR DESCRIPTION
Avoid launching the TRR test suite GUI in full screen, which could be tricky to exit in some remote sessions (VNC, remote servers, ...).