### PR TITLE
Update optional CTADIRAC installation instructions

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -59,7 +59,7 @@ From: condaforge/mambaforge
     conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses
     mamba deactivate
     mamba activate nectarchain
-    pip install CTADIRAC
+    pip install "CTADIRAC<3"
 
     # Since there is no proxy available at build time, manually configure the CTADIRAC client
     cat <<EOF > ${CONDA_PREFIX}/etc/dirac.cfg

--- a/docs/developer-guide/getting-started.rst
+++ b/docs/developer-guide/getting-started.rst
@@ -46,12 +46,12 @@ To enable support for DIRAC within the same environment, do the following after 
 .. code-block:: console
 
    $ mamba activate nectarchain
-   $ mamba install dirac-grid
-   $ conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses
+   $ mamba install -c conda-forge dirac-grid
+   $ conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses DIRACSYSCONFIG=${CONDA_PREFIX}/etc/dirac.cfg
    $ # The following is needed for the environment variables, used for DIRAC configuration, to be available:
    $ mamba deactivate
    $ mamba activate nectarchain
-   $ pip install CTADIRAC
+   $ pip install "CTADIRAC<3"
    $ dirac-configure
 
 

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -22,13 +22,13 @@ installation process (see :ref:`optional-dirac-support`), instead of:
 
 .. code-block:: console
 
-   $ mamba install dirac-grid
+   $ mamba install -c conda-forge dirac-grid
 
 one may try:
 
 .. code-block:: console
 
-  $ mamba install dirac-grid "voms=2.1.0rc2=h7a71a8a_7"
+  $ mamba install -c conda-forge dirac-grid "voms=2.1.0rc2=h7a71a8a_7"
 
 
 Using a container

--- a/src/nectarchain/dqm/vm/dqm-web-app-rw_cloud-init.yml
+++ b/src/nectarchain/dqm/vm/dqm-web-app-rw_cloud-init.yml
@@ -121,9 +121,9 @@ runcmd:
   - mamba env create --name nectarchain --file environment.yml
   - mamba activate nectarchain
   - pip install -e .
-  - mamba install dirac-grid
-  - pip install CTADIRAC
-  - conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses
+  - mamba install -c conda-forge dirac-grid
+  - pip install "CTADIRAC<3"
+  - conda env config vars set X509_CERT_DIR=${CONDA_PREFIX}/etc/grid-security/certificates X509_VOMS_DIR=${CONDA_PREFIX}/etc/grid-security/vomsdir X509_VOMSES=${CONDA_PREFIX}/etc/grid-security/vomses DIRACSYSCONFIG=${CONDA_PREFIX}/etc/dirac.cfg
   - mamba deactivate
   - chown -R nectarcam:cta /opt/cta
   - chown -R nectarcam:cta /opt/conda


### PR DESCRIPTION
This PR is linked to #220 and propose to pin to CTADIRAC < 3 for the moment (until the CTADIRAC legacy instance is migrated to DIRAC v9/DiracX).