### PR TITLE
Update x86 macOS runner in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
             ctapipe-version: "v0.24.0"
             install-method: "pip"
             extra-args: ["codecov"]
-          # macos 13 image is x86-based
-          - os: "macos-13"
+          # macos 15 image, x86-based
+          - os: "macos-15-intel"
             python-version: "3.11"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"


### PR DESCRIPTION
x86-based macOS 13 runner image is being deprecated (https://github.com/actions/runner-images/issues/13046), making the CI on these runners fail. The `macos-15-intel` image will be the last x86-based image provided for macOS runners, available until August 2027.