### PR TITLE
Fix #247

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -107,7 +107,6 @@ EOF
 EOF
     ln -s /etc/grid-security/certificates ${CONDA_PREFIX}/etc/grid-security/.
 
-    mamba clean --quiet -y --all
     echo "## Activate nectarchain environment" >> /.singularity_bash
     echo "source /opt/conda/etc/profile.d/conda.sh" >> /.singularity_bash
     echo "source /opt/conda/etc/profile.d/mamba.sh" >> /.singularity_bash


### PR DESCRIPTION
Cleaning mamba packages when building Apptainer images may have unwanted side effects, such as deleting PyQt, which we do not want, since the SPE fit algorithm depends on `pyqtgraph` for plots, which itself depends on PyQt.