### PR TITLE
Fix of units in TRR pixel timing uncertainty script

### DIFF
--- a/src/nectarchain/trr_test_suite/pix_tim_uncertainty.py
+++ b/src/nectarchain/trr_test_suite/pix_tim_uncertainty.py
@@ -117,7 +117,6 @@ def main():
         mean_charge_pe.append(output[2])
 
     print(rms_no_fit)
-    photons_spline = np.array(mean_charge_pe) * 100 / 25
     rms_no_fit_err = np.array(rms_no_fit_err)
     print(rms_no_fit_err)
     rms_no_fit_err[rms_no_fit_err == 0] = 1e-5  # almost zero
@@ -154,7 +153,7 @@ def main():
     fig, ax = plt.subplots(figsize=(10, 7), constrained_layout=True)
 
     plt.errorbar(
-        x=photons_spline[:],
+        x=mean_charge_pe[:],
         y=np.sqrt(np.array(rms_no_fit_weighted[:]) ** 2),
         yerr=rms_no_fit_weighted_err,
         ls="",
@@ -176,7 +175,7 @@ def main():
         label="Quantification rms noise",
     )
 
-    plt.axvspan(20, 1000, alpha=0.1, color="C4")
+    plt.axvspan(photons2pe(20), photons2pe(1000), alpha=0.1, color="C4")
 
     ax.text(
         51.5,
@@ -206,12 +205,12 @@ def main():
     )
 
     plt.legend(frameon=True, prop={"size": 18}, loc="upper right", handlelength=1.2)
-    plt.xlabel("Illumination charge [photons]")
+    plt.xlabel("Illumination charge [p.e.]")
     plt.ylabel("Mean rms per pixel [ns]")
     plt.xscale("log")
     plt.ylim((0, 2.7))
     secax = ax.secondary_xaxis("top", functions=(pe2photons, photons2pe))
-    secax.set_xlabel("Illumination charge [p.e.]", labelpad=7)
+    secax.set_xlabel("Illumination charge [photons]", labelpad=7)
     plt.savefig(os.path.join(output_dir, "pix_tim_uncertainty.png"))
 
     if temp_output:


### PR DESCRIPTION
Before this PR, the plots from `nectarchain/trr_test_suite/pix_tim_uncertainty.py` gave the wrong units:

<img width="1000" height="700" alt="image" src="https://github.com/user-attachments/assets/41beb5ca-29da-4400-9469-f6b6b126d36c" />

This is now fixed (the difference in the data points is simply due to different number of events used in the computation):

<img width="1000" height="700" alt="image" src="https://github.com/user-attachments/assets/c5fa1e2f-49cc-4f1d-bdd5-0ec1da6efff0" />

Top and bottom axes have also been flipped so that it corresponds well to the plot of e.g. the [timing paper](https://arxiv.org/abs/2301.13828):

<img width="666" height="459" alt="Screenshot 2026-02-06 at 17 34 00" src="https://github.com/user-attachments/assets/4da7849e-42b6-42d9-9dfe-df26ab3c13fe" />
