### PR TITLE
ToM Calculation

### DIFF
--- a/src/nectarchain/trr_test_suite/pix_couple_tim_uncertainty.py
+++ b/src/nectarchain/trr_test_suite/pix_couple_tim_uncertainty.py
@@ -151,7 +151,7 @@ def main():
             max_events=nevents,
             log_level=20,
             method="LocalPeakWindowSum",
-            extractor_kwargs={"window_width": 16, "window_shift": 6},
+            extractor_kwargs={"window_width": 6, "window_shift": 3}, #This width and shift works best for ToM calculation
             overwrite=True,
             pedestal_file=pedestal_tool.output_path,
             use_default_pedestal=True,  # only done if pedestal_file cannot be loaded

--- a/src/nectarchain/trr_test_suite/pix_couple_tim_uncertainty.py
+++ b/src/nectarchain/trr_test_suite/pix_couple_tim_uncertainty.py
@@ -151,7 +151,10 @@ def main():
             max_events=nevents,
             log_level=20,
             method="LocalPeakWindowSum",
-            extractor_kwargs={"window_width": 6, "window_shift": 3}, #This width and shift works best for ToM calculation
+            extractor_kwargs={
+                "window_width": 6,
+                "window_shift": 3,
+            },  # This width and shift works best for ToM calculation
             overwrite=True,
             pedestal_file=pedestal_tool.output_path,
             use_default_pedestal=True,  # only done if pedestal_file cannot be loaded

--- a/src/nectarchain/trr_test_suite/pix_tim_uncertainty.py
+++ b/src/nectarchain/trr_test_suite/pix_tim_uncertainty.py
@@ -135,7 +135,7 @@ def main():
             events_per_slice=9999,
             log_level=20,
             method="LocalPeakWindowSum",
-            extractor_kwargs={"window_width": 16, "window_shift": 6},
+            extractor_kwargs={"window_width": 6, "window_shift": 3}, #This width and shift works best for ToM calculation
             overwrite=True,
             pedestal_file=pedestal_tool.output_path,
             use_default_pedestal=True,  # only done if pedestal_file cannot be loaded

--- a/src/nectarchain/trr_test_suite/pix_tim_uncertainty.py
+++ b/src/nectarchain/trr_test_suite/pix_tim_uncertainty.py
@@ -135,7 +135,10 @@ def main():
             events_per_slice=9999,
             log_level=20,
             method="LocalPeakWindowSum",
-            extractor_kwargs={"window_width": 6, "window_shift": 3}, #This width and shift works best for ToM calculation
+            extractor_kwargs={
+                "window_width": 6,
+                "window_shift": 3,
+            },  # This width and shift works best for ToM calculation
             overwrite=True,
             pedestal_file=pedestal_tool.output_path,
             use_default_pedestal=True,  # only done if pedestal_file cannot be loaded


### PR DESCRIPTION
Changed the "window width" and "window shift" parameters of the tools that work on ToM calculation. This does not affect event rejection, or charge calculation (which is not needed for these tools). The result gives ToMs that have the same mean as those of the CubicSpline interpolation but with only slightly higher dispersion (+/- 0.2ns on high flasher intensities) I have included a supporting plot.
<img width="640" height="480" alt="ToM Calculation Difference 7152 16V Flasher ctapipeonlycubic" src="https://github.com/user-attachments/assets/f33d9e07-6fa9-4870-bb8c-c49d343409fd" />

<img width="640" height="480" alt="ToM Calculation Difference 7144 8V Flasher ctapipeonlycubic" src="https://github.com/user-attachments/assets/932d60c1-6922-42c2-8a1b-a1171ff1e560" />
