### PR TITLE
Add event timestamps to the trigger_statistics.py output in the DQM

### DIFF
--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -102,11 +102,11 @@ class TriggerStatistics(DQMSummary):
             "Wrong times": [len(self.event_wrong_times)],
         }
         self.TriggerStat_Results_Dict["TRIGGER-EVENT-TIMESTAMPS"] = {
-            "All": self.event_times,
-            "Physical": self.event_phy_times,
-            "Pedestals": self.event_ped_times,
-            "Others": self.event_other_times,
-            "Wrong times": self.event_wrong_times,
+            "All": np.array(self.event_times),
+            "Physical": np.array(self.event_phy_times),
+            "Pedestals": np.array(self.event_ped_times),
+            "Others": np.array(self.event_other_times),
+            "Wrong times": np.array(self.event_wrong_times),
         }
         self.TriggerStat_Results_Dict["START-TIMES"] = {
             "Run start time": [self.run_start1],

--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -101,6 +101,13 @@ class TriggerStatistics(DQMSummary):
             "Others": [len(self.event_other_times)],
             "Wrong times": [len(self.event_wrong_times)],
         }
+        self.TriggerStat_Results_Dict["TRIGGER-EVENT-TIMESTAMPS"] = {
+            "All": self.event_times,
+            "Physical": self.event_phy_times,
+            "Pedestals": self.event_ped_times,
+            "Others": self.event_other_times,
+            "Wrong times": self.event_wrong_times,
+        }
         self.TriggerStat_Results_Dict["START-TIMES"] = {
             "Run start time": [self.run_start1],
             "First event": [self.run_start],

--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -108,6 +108,13 @@ class TriggerStatistics(DQMSummary):
             "Others": np.array(self.event_other_times),
             "Wrong times": np.array(self.event_wrong_times),
         }
+        self.TriggerStat_Results_Dict["TRIGGER-EVENT-IDS"] = {
+            "All": np.array(self.event_id),
+            "Physical": np.array(self.event_phy_id),
+            "Pedestals": np.array(self.event_ped_id),
+            "Others": np.array(self.event_other_id),
+            "Wrong times": np.array(self.event_wrong_id),
+        }
         self.TriggerStat_Results_Dict["START-TIMES"] = {
             "Run start time": [self.run_start1],
             "First event": [self.run_start],


### PR DESCRIPTION
This PR adds two subdictionaries to the results dictionary output of get_results() in trigger_statistics.py. This is needed to write into the database for future display on the DQM web app.