### PR TITLE
Save waveforms for all pixels extracted by the DQM in the database

### DIFF
--- a/src/nectarchain/dqm/__init__.py
+++ b/src/nectarchain/dqm/__init__.py
@@ -6,17 +6,17 @@ from .camera_monitoring import CameraMonitoring
 from .charge_integration import ChargeIntegrationHighLowGain
 from .dqm_summary_processor import DQMSummary
 from .mean_camera_display import MeanCameraDisplayHighLowGain
-from .mean_waveforms import MeanWaveFormsHighLowGain
 from .pixel_participation import PixelParticipationHighLowGain
 from .pixel_timeline import PixelTimelineHighLowGain
 from .trigger_statistics import TriggerStatistics
+from .waveforms import WaveFormsHighLowGain
 
 __all__ = [
     "CameraMonitoring",
     "ChargeIntegrationHighLowGain",
     "DQMSummary",
     "MeanCameraDisplayHighLowGain",
-    "MeanWaveFormsHighLowGain",
+    "WaveFormsHighLowGain",
     "PixelParticipationHighLowGain",
     "PixelTimelineHighLowGain",
     "TriggerStatistics",

--- a/src/nectarchain/dqm/start_dqm.py
+++ b/src/nectarchain/dqm/start_dqm.py
@@ -16,10 +16,10 @@ from nectarchain.dqm.camera_monitoring import CameraMonitoring
 from nectarchain.dqm.charge_integration import ChargeIntegrationHighLowGain
 from nectarchain.dqm.db_utils import DQMDB
 from nectarchain.dqm.mean_camera_display import MeanCameraDisplayHighLowGain
-from nectarchain.dqm.mean_waveforms import MeanWaveFormsHighLowGain
 from nectarchain.dqm.pixel_participation import PixelParticipationHighLowGain
 from nectarchain.dqm.pixel_timeline import PixelTimelineHighLowGain
 from nectarchain.dqm.trigger_statistics import TriggerStatistics
+from nectarchain.dqm.waveforms import WaveFormsHighLowGain
 from nectarchain.makers import ChargesNectarCAMCalibrationTool
 from nectarchain.utils.constants import ALLOWED_CAMERAS
 
@@ -207,8 +207,8 @@ def main():
     ####################################################################################
     processors = [
         TriggerStatistics(HIGH_GAIN, args.r0),
-        MeanWaveFormsHighLowGain(HIGH_GAIN, args.r0),
-        MeanWaveFormsHighLowGain(LOW_GAIN, args.r0),
+        WaveFormsHighLowGain(HIGH_GAIN, args.r0),
+        WaveFormsHighLowGain(LOW_GAIN, args.r0),
         MeanCameraDisplayHighLowGain(HIGH_GAIN, args.r0),
         MeanCameraDisplayHighLowGain(LOW_GAIN, args.r0),
         ChargeIntegrationHighLowGain(HIGH_GAIN, args.r0),
@@ -225,8 +225,8 @@ def main():
 
     NESTED_DICT_KEYS = [
         "Results_TriggerStatistics",
-        "Results_MeanWaveForms_HighGain",
-        "Results_MeanWaveForms_LowGain",
+        "Results_WaveForms_HighGain",
+        "Results_WaveForms_LowGain",
         "Results_MeanCameraDisplay_HighGain",
         "Results_MeanCameraDisplay_LowGain",
         "Results_ChargeIntegration_HighGain",

--- a/src/nectarchain/dqm/tests/test_waveforms.py
+++ b/src/nectarchain/dqm/tests/test_waveforms.py
@@ -1,0 +1,37 @@
+import numpy as np
+from ctapipe.utils import get_dataset_path
+from ctapipe_io_nectarcam import LightNectarCAMEventSource as EventSource
+from ctapipe_io_nectarcam.constants import HIGH_GAIN
+from tqdm import tqdm
+from traitlets.config import Config
+
+from nectarchain.dqm.waveforms import WaveFormsHighLowGain
+
+
+class TestWaveForms:
+    def test_mean_waveforms(self):
+        path = get_dataset_path("NectarCAM.Run3938.30events.fits.fz")
+
+        config = Config(
+            dict(
+                NectarCAMEventSource=dict(
+                    NectarCAMR0Corrections=dict(
+                        calibration_path=None,
+                        apply_flatfield=False,
+                        select_gain=False,
+                    )
+                )
+            )
+        )
+
+        reader1 = EventSource(input_url=path, config=config, max_events=1)
+        tel_id = reader1.subarray.tel_ids[0]
+
+        Pix, Samp = WaveFormsHighLowGain(HIGH_GAIN, r0=True).define_for_run(reader1)
+
+        evt = None
+        for evt in tqdm(reader1, total=1):
+            self.pixelBAD = evt.mon.tel[tel_id].pixel_status.hardware_failing_pixels
+
+        assert Pix + Samp == 1915
+        assert np.sum(evt.r0.tel[tel_id].waveform[HIGH_GAIN][0]) == 3932100

--- a/src/nectarchain/dqm/waveforms.py
+++ b/src/nectarchain/dqm/waveforms.py
@@ -1,0 +1,172 @@
+import os
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from .dqm_summary_processor import DQMSummary
+
+__all__ = ["WaveFormsHighLowGain"]
+
+
+class WaveFormsHighLowGain(DQMSummary):
+    def __init__(self, gaink, r0=False):
+        self.k = gaink
+        self.Pix = None
+        self.Samp = None
+        self.tel_id = None
+        self.wf = None
+        self.wf_ped = None
+        self.counter_evt = None
+        self.counter_ped = None
+        self.wf_average = None
+        self.wf_ped_average = None
+        self.wf_mean_over_pix = []
+        self.wf_ped_mean_over_pix = []
+        self.MeanWaveForms_Results_Dict = {}
+        self.MeanWaveForms_Figures_Dict = {}
+        self.MeanWaveForms_Figures_Names_Dict = {}
+
+        self.wf_list_plot = None
+
+        gain_c = "High" if self.k == 0 else "Low"
+        self.gain_c = gain_c
+
+        self.figure_keys = {
+            "physical": f"FIGURE-WF-Physical-{gain_c}-GAIN",
+            "pedestals": f"FIGURE-WF-Pedestals-{gain_c}-GAIN",
+            "combined": f"FIGURE-WF-COMBINED-{gain_c}-GAIN",
+        }
+
+        self.figure_filenames = {
+            "physical": f"_MeanWaveforms_Physical_{gain_c}Gain.png",
+            "pedestals": f"_MeanWaveforms_Pedestals_{gain_c}Gain.png",
+            "combined": f"_MeanWaveforms_CombinedPlot_{gain_c}Gain.png",
+        }
+
+        super().__init__(r0)
+
+    def configure_for_run(self, path, Pix, Samp, Reader1, **kwargs):
+        """Initialize waveform buffers and counters for a new run."""
+        self.Pix = Pix
+        self.Samp = Samp
+
+        self.tel_id = Reader1.subarray.tel_ids[0]
+
+        self.wf = np.zeros((Pix, Samp))
+        self.wf_ped = np.zeros((Pix, Samp))
+
+        self.counter_evt = 0
+        self.counter_ped = 0
+
+        self.wf_average = np.zeros((Pix, Samp))
+        self.wf_ped_average = np.zeros((Pix, Samp))
+
+        self.wf_list_plot = list(np.arange(1, Samp + 1))
+
+    def process_event(self, evt, noped):
+        if evt.trigger.event_type.value == 32:  # only peds now
+            self.counter_ped += 1
+        else:
+            self.counter_evt += 1
+
+        for ipix in range(self.Pix):
+            if self.r0:
+                waveform = evt.r0.tel[self.tel_id].waveform[self.k][ipix]
+            else:
+                # This should accommodate cases were the shape of waveforms is 2D
+                # (1855,60), or 3D (2, 1855, 60) for 2-gain channels or
+                # (1, 1855, 60) for single-gain channel
+                waveform = evt.r1.tel[self.tel_id].waveform[..., ipix, :]
+            if evt.trigger.event_type.value == 32:  # only peds now
+                self.wf_ped[ipix, :] += waveform
+            else:
+                self.wf[ipix, :] += waveform
+        return None
+
+    def finish_run(self):
+        """Compute mean waveforms over events and pixels."""
+
+        if self.counter_evt > 0:
+            self.wf_average = self.wf / self.counter_evt  # get average
+            # get average over pixels
+            self.wf_mean_over_pix = np.mean(self.wf_average, axis=0)
+
+        if self.counter_ped > 0:
+            # get average pedestals
+            self.wf_ped_average = self.wf_ped / self.counter_ped
+            self.wf_ped_mean_over_pix = np.mean(self.wf_ped_average, axis=0)
+
+        return None
+
+    def get_results(self):
+        """Store waveform statistics in results dictionary by gain and type."""
+
+        self.MeanWaveForms_Results_Dict[
+            f"WF-PHY-AVERAGE-PIX-{self.gain_c.upper()}-GAIN"
+        ] = self.wf_mean_over_pix
+        self.MeanWaveForms_Results_Dict[
+            f"WF-PHY-{self.gain_c.upper()}-GAIN"
+        ] = self.wf_average
+        if self.counter_ped > 0:
+            self.MeanWaveForms_Results_Dict[
+                f"WF-PED-AVERAGE-PIX-{self.gain_c.upper()}-GAIN"
+            ] = self.wf_ped_mean_over_pix
+            self.MeanWaveForms_Results_Dict[
+                f"WF-PED-{self.gain_c.upper()}-GAIN"
+            ] = self.wf_ped_average
+
+        return self.MeanWaveForms_Results_Dict
+
+    def plot_results(self, name, fig_path):
+        wf_list = np.array(self.wf_list_plot)
+
+        colors = ["black", "red"]
+        titles = ["physical", "pedestals"]
+
+        full_fig, full_ax = plt.subplots()
+        array_plot = [self.wf_average]
+
+        if self.counter_ped > 0:
+            array_plot.append(self.wf_ped_average)
+
+        for i, x in enumerate(array_plot):
+            key = titles[i]
+            fig_key = self.figure_keys[key]
+            full_name = name + self.figure_filenames[key]
+            fig_name = os.path.join(fig_path, full_name)
+
+            part_fig, part_ax = plt.subplots()
+
+            for ipix in range(self.Pix):
+                part_ax.plot(
+                    wf_list, x[ipix, :], color=colors[i], alpha=0.08, linewidth=1
+                )
+                full_ax.plot(
+                    wf_list, x[ipix, :], color=colors[i], alpha=0.08, linewidth=1
+                )
+
+            part_ax.set_title(f"Mean Waveforms {key.capitalize()} ({self.gain_c} Gain)")
+            part_ax.set_xlabel("Samples")
+            part_ax.set_ylabel("Amplitude (DC)")
+            part_ax.grid()
+
+            self.MeanWaveForms_Figures_Dict[fig_key] = part_fig
+            self.MeanWaveForms_Figures_Names_Dict[fig_key] = fig_name
+
+            plt.close(part_fig)
+
+        # Combined figure setup
+        full_ax.set_title(f"Mean Waveforms Combined Plot ({self.gain_c} Gain)")
+        full_ax.set_xlabel("Samples")
+        full_ax.set_ylabel("Amplitude (DC)")
+        full_ax.grid()
+
+        combined_key = self.figure_keys["combined"]
+        combined_path = os.path.join(fig_path, name + self.figure_filenames["combined"])
+
+        self.MeanWaveForms_Figures_Dict[combined_key] = full_fig
+        self.MeanWaveForms_Figures_Names_Dict[combined_key] = combined_path
+
+        plt.close(full_fig)
+
+        return self.MeanWaveForms_Figures_Dict, self.MeanWaveForms_Figures_Names_Dict


### PR DESCRIPTION
feat(src/nectarchain/dqm):
- __init__.py: change processor init name for waveforms
- waveforms.py: moved from mean_waveforms.py, include all waveforms (not only one averaged over all pixels) in the dictionary saved to database
- start_dqm.py: minor fixes following changes in waveforms processor script
- tests/test_waveforms.py: fixed tests

This PR includes the saving of the waveforms for all the pixels to the database, not only the one averaged over all pixels. For consistency, the processor has been renamed `waveforms.py`, from `mean_waveforms.py`. `__init__.py`, `start_dqm.py`, and `test_waveforms.py` have been updated accordingly.