### PR TITLE
Fix `FlatFieldComponent` so that it can be used for runs with an incomplete camera

### DIFF
--- a/src/nectarchain/makers/component/flatfield_component.py
+++ b/src/nectarchain/makers/component/flatfield_component.py
@@ -229,7 +229,7 @@ of the waveform"
             )
 
             # get the waveform
-            wfs = event.r0.tel[self.tel_id].waveform
+            wfs = event.r0.tel[self.tel_id].waveform[:, self.pixels_id]
 
             # subtract pedestal container if filled
             # otherwise use the mean of the n first samples
@@ -267,13 +267,21 @@ of the waveform"
                     wfs_pedsub, axis=-1, where=masked_wfs
                 )
 
-                amp_int_per_pix_per_event[self.__bad_pixels_mask] = np.nan
+                amp_int_per_pix_per_event[
+                    self.__bad_pixels_mask[:, self.pixels_id]
+                ] = np.nan
                 # amp_int_per_pix_per_event = np.ma.array(
                 #    amp_int_per_pix_per_event, mask=self.__bad_pixels_mask
                 # )
 
                 self.__amp_int_per_pix_per_event.append(amp_int_per_pix_per_event)
-                amp_int_per_pix_per_event_pe = amp_int_per_pix_per_event / self.gain
+                if len(self.gain[constants.HIGH_GAIN]) > self.npixels:
+                    amp_int_per_pix_per_event_pe = (
+                        amp_int_per_pix_per_event
+                        / np.array(self.gain)[:, self.pixels_id]
+                    )
+                else:
+                    amp_int_per_pix_per_event_pe = amp_int_per_pix_per_event / self.gain
 
             else:
                 config = Config(
@@ -297,9 +305,15 @@ of the waveform"
                 amp_int_per_pix_per_event.image[:, self.__bad_pixels_number] = np.nan
                 self.__amp_int_per_pix_per_event.append(amp_int_per_pix_per_event.image)
 
-                amp_int_per_pix_per_event_pe = (
-                    amp_int_per_pix_per_event.image[:] / self.gain[:]
-                )
+                if len(self.gain[constants.HIGH_GAIN]) > self.npixels:
+                    amp_int_per_pix_per_event_pe = (
+                        amp_int_per_pix_per_event.image
+                        / np.array(self.gain)[:, self.pixels_id]
+                    )
+                else:
+                    amp_int_per_pix_per_event_pe = (
+                        amp_int_per_pix_per_event.image / self.gain
+                    )
 
             # amp_int_per_pix_per_event_pe = np.ma.masked_array(
             #    amp_int_per_pix_per_event_pe,
@@ -310,7 +324,7 @@ of the waveform"
             mean_amp_cam_per_event_pe = np.mean(
                 amp_int_per_pix_per_event_pe,
                 axis=-1,
-                where=np.invert(self.__bad_pixels_mask),
+                where=np.invert(self.__bad_pixels_mask[:, self._pixels_id]),
             )
 
             # efficiency coefficients
@@ -334,8 +348,12 @@ of the waveform"
         """
 
         wfs_pedsub = np.copy(wfs)
-        wfs_pedsub[constants.HIGH_GAIN] -= self.__pedestal_container["pedestal_mean_hg"]
-        wfs_pedsub[constants.LOW_GAIN] -= self.__pedestal_container["pedestal_mean_lg"]
+        wfs_pedsub[constants.HIGH_GAIN] -= self.__pedestal_container[
+            "pedestal_mean_hg"
+        ][self._pixels_id]
+        wfs_pedsub[constants.LOW_GAIN] -= self.__pedestal_container["pedestal_mean_lg"][
+            self._pixels_id
+        ]
 
         return wfs_pedsub
 

--- a/src/nectarchain/makers/component/flatfield_component.py
+++ b/src/nectarchain/makers/component/flatfield_component.py
@@ -321,7 +321,7 @@ of the waveform"
             #    | (~np.isfinite(amp_int_per_pix_per_event_pe)),
             # )
 
-            mean_amp_cam_per_event_pe = np.mean(
+            mean_amp_cam_per_event_pe = np.nanmean(
                 amp_int_per_pix_per_event_pe,
                 axis=-1,
                 where=np.invert(self.__bad_pixels_mask[:, self._pixels_id]),

--- a/src/nectarchain/makers/component/flatfield_component.py
+++ b/src/nectarchain/makers/component/flatfield_component.py
@@ -238,7 +238,7 @@ of the waveform"
             else:
                 # check location of the peak
                 toms = np.argmax(wfs, axis=-1)
-                tom = toms[0]
+                tom = toms[constants.HIGH_GAIN]
                 tom_mean = np.mean(tom)
                 tom_std = np.std(tom, ddof=1)
 

--- a/src/nectarchain/user_scripts/ajardinb/flatfield_example.py
+++ b/src/nectarchain/user_scripts/ajardinb/flatfield_example.py
@@ -105,7 +105,7 @@ def get_bad_pixels(output_from_FlatFieldComponent):
         all_bad_pix: list of bad pixels
     """
 
-    pix_id = FlatFieldOutput.pixels_id
+    pix_id = output_from_FlatFieldComponent.pixels_id
     bad_pix = []
 
     n_event = len(output_from_FlatFieldComponent.amp_int_per_pix_per_event[:, 0, 0])

--- a/src/nectarchain/user_scripts/ajardinb/flatfield_example.py
+++ b/src/nectarchain/user_scripts/ajardinb/flatfield_example.py
@@ -119,7 +119,7 @@ def get_bad_pixels(output_from_FlatFieldComponent):
     mean_amp = np.mean(mean_amp_int_per_pix, axis=1)
     std_amp = np.std(mean_amp_int_per_pix, axis=1)
 
-    for p in range(0, constants.N_PIXELS):
+    for p in range(0, len(pix_id)):
         # pixel with hi/lo ratio to small or to high (+/- 5 times the mean hi/lo ratio)
         if (hi_lo[p] < np.mean(hi_lo) - (5 * np.std(hi_lo))) or (
             hi_lo[p] > np.mean(hi_lo) + (5 * np.std(hi_lo))


### PR DESCRIPTION
This is a _temporary_ ugly workaround so that the `FlatFieldComponent` can correctly treat runs without a complete camera.

For any `ArrayDataComponent` (such as a `WaveformsComponent` or `ChargesComponent`), waveforms are naturally only selected for the available pixels in the camera (see [here](https://github.com/cta-observatory/nectarchain/blob/2c5f079eb1c8742ccf0f7a64e7963269bdfac91f/src/nectarchain/makers/component/core.py#L55)). This PR tries to mimic that during the waveform extraction and manipulation in the `FlatFieldComponent`, basically by just selecting the `self.pixels_id` which are defined by the parent `NectarCAMComponent` (where it is already taken into account which pixels were used for the run). 

To test that it's indeed working, use the example script of @ArmelleJB (`user_scripts/ajardinb/flatfield_example.py`) as follows, for [run 6253](http://nectarcam.in2p3.fr/elog/nectarcam-data-qm/?mode=full&reverse=0&reverse=1&npp=20&Subject=6239) which contains 1544 pixels:

`python flatfield_example.py -r 6253 -m 1000`
**NOTE**: You should set `window_shift = 4` in the script, otherwise all pixels will be tagged as bad in the first run. I also checked that this works by specifying a `pedestal_file` and `gain_file` in the script. 

In any case, this whole manipulation of waveforms is only necessary so that we can apply the two-pass method in `flatfield_example.py`. However, at some point we can just start using the existing gain tools to compute the gain, making the two-pass method obsolete. When we decide to do that, we should just use a `ChargesComponent` subcomponent in `FlatFieldComponent.__call__()` (like done in most other components), and perform the `eff_coef` computations in `FlatFieldComponent.finish()`. That way we also won't have to save all the charges in the output of the `FlatFieldComponent`. Just something to keep in mind :) 