### PR TITLE
Add detailed HoverTool to Bokeh app

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -9,7 +9,7 @@ from astropy.coordinates import SkyCoord
 
 # bokeh imports
 from bokeh.layouts import column, row
-from bokeh.models import ColorBar, Label, Node, TabPanel
+from bokeh.models import ColorBar, HoverTool, Label, Node, TabPanel
 from bokeh.plotting import figure
 
 # ctapipe imports
@@ -642,6 +642,51 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
     return scatter_value_vs_id
 
 
+def compile_hover_tool(display, camgeom):
+    geom_info = camgeom.to_table()
+    pix_id = geom_info["pix_id"].data
+    pixel_number = len(pix_id)
+    pix_id = np.reshape(pix_id, (int(pixel_number / 7), 7))
+    pix_x = np.round(geom_info["pix_x"].data, decimals=3)
+    pix_y = np.round(geom_info["pix_y"].data, decimals=3)
+
+    cluster_n = []
+    pix_id_in_cluster = []
+
+    for ii in range(pix_id.shape[0]):
+        for jj in range(pix_id.shape[1]):
+            cluster_n.append(ii)
+            pix_id_in_cluster.append(jj)
+
+    pix_id = np.reshape(pix_id, (pixel_number,))
+
+    image = display.image
+
+    display.datasource.add(pix_id, "pix_id")
+    display.datasource.add(pix_x, "pix_x")
+    display.datasource.add(pix_y, "pix_y")
+    display.datasource.add(cluster_n, "cluster_n")
+    display.datasource.add(pix_id_in_cluster, "pix_id_in_cluster")
+    display.datasource.add(image, "image")
+
+    display.figure.add_tools(
+        HoverTool(
+            tooltips=[
+                ("pix id", "@pix_id"),
+                ("pix # in cluster", "@pix_id_in_cluster"),
+                ("cluster #", "@cluster_n"),
+                ("pix x pos", "@pix_x"),
+                ("pix y pos", "@pix_y"),
+                ("value", "@image"),
+            ],
+            mode="mouse",
+            point_policy="snap_to_data",
+        )
+    )
+
+    return display
+
+
 # TODO: some more explanation about the parent and child keys
 # may help the user, if needed
 def make_camera_display(source, parent_key, child_key):
@@ -751,6 +796,8 @@ def make_camera_display(source, parent_key, child_key):
         color_bar.title = ""
 
     display.figure.title = child_key
+
+    display = compile_hover_tool(display=display, camgeom=geom)
 
     return display
 

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -9,7 +9,7 @@ from astropy.coordinates import SkyCoord
 
 # bokeh imports
 from bokeh.layouts import column, row
-from bokeh.models import ColorBar, HoverTool, Label, Node, TabPanel
+from bokeh.models import ColorBar, ColumnDataSource, HoverTool, Label, Node, TabPanel
 from bokeh.plotting import figure
 
 # ctapipe imports
@@ -564,6 +564,36 @@ def make_pixel_vals_histo(source, parent_key, child_key):
     return histo_values
 
 
+def compile_hover_tool_val_vs_id(pixel_data, figure):
+    """Compile the HoverTool for the
+       input scatter figure with additional information
+
+    Parameters
+    ----------
+    pixel_data : bokeh.plotting.figure.scatter
+        Scatter plot defined and already filled
+        in the corresponding function
+    figure : bokeh.plotting.figure
+        Figure object to add the HoverTool to
+
+    Returns
+    -------
+    bokeh.plotting.figure
+        Figure object with the HoverTool added
+    """
+
+    figure.add_tools(
+        HoverTool(
+            tooltips=[("(pix_id, value)", "(@pix_id, @value)")],
+            mode="mouse",
+            point_policy="snap_to_data",
+            renderers=[pixel_data],
+        )
+    )
+
+    return figure
+
+
 def make_pixel_val_vs_id(source, parent_key, child_key):
     """Make 1D plot of camera pixel values vs pixel id
        to fill the nested dict
@@ -621,9 +651,11 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
         y_range=(min_val, max_val),
     )
 
-    scatter_value_vs_id.scatter(
-        x=np.arange(len(image)),
-        y=image,
+    data_source = ColumnDataSource(data=dict(pix_id=np.arange(len(image)), value=image))
+    pixel_data = scatter_value_vs_id.scatter(
+        x="pix_id",
+        y="value",
+        source=data_source,
         color="blue",
         size=5,
         alpha=0.6,
@@ -638,6 +670,10 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
     scatter_value_vs_id.yaxis.major_label_text_font_size = "10pt"
     scatter_value_vs_id.xaxis.axis_label_text_font_style = "normal"
     scatter_value_vs_id.yaxis.axis_label_text_font_style = "normal"
+
+    scatter_value_vs_id = compile_hover_tool_val_vs_id(
+        pixel_data=pixel_data, figure=scatter_value_vs_id
+    )
 
     return scatter_value_vs_id
 

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -643,6 +643,22 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
 
 
 def compile_hover_tool(display, camgeom):
+    """_summary_
+
+    Parameters
+    ----------
+    display : ctapipe.visualization.bokeh.CameraDisplay
+        CameraDisplay already filled with values
+    camgeom : ctapipe.instrument.CameraGeometry
+        CameraGeometry object containing the camera layout information
+
+    Returns
+    -------
+    ctapipe.visualization.bokeh.CameraDisplay
+        CameraDisplay as input but now with the HoverTool
+        added to the figure, to show pixel information on hover
+    """
+
     geom_info = camgeom.to_table()
     pix_id = geom_info["pix_id"].data
     pixel_number = len(pix_id)

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -643,7 +643,8 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
 
 
 def compile_hover_tool(display, camgeom):
-    """_summary_
+    """Compile the HoverTool for the
+       input camera display with additional information
 
     Parameters
     ----------

--- a/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
@@ -3,7 +3,7 @@ import numpy as np
 # bokeh imports
 from bokeh.io import output_file, save
 from bokeh.layouts import column, row
-from bokeh.models import Select, TabPanel, Tabs
+from bokeh.models import HoverTool, Select, TabPanel, Tabs
 from bokeh.plotting import curdoc
 
 # ctapipe imports
@@ -293,3 +293,65 @@ def test_bokeh(tmp_path):
     output_path = tmp_path / "test.html"
     output_file(output_path)
     save(curdoc(), filename=output_path)
+
+
+def test_compile_hover_tool():
+    from ctapipe.visualization.bokeh import CameraDisplay
+
+    from nectarchain.dqm.bokeh_app.app_hooks import compile_hover_tool
+
+    display = CameraDisplay(geometry=geom)
+    display.image = np.random.normal(size=geom.n_pixels)
+
+    result = compile_hover_tool(display, geom)
+
+    # Verify the function returns a display object
+    assert isinstance(result, CameraDisplay)
+
+    # Verify datasource was populated with expected columns
+    datasource_data = result.datasource.data
+    expected_keys = [
+        "pix_id",
+        "pix_x",
+        "pix_y",
+        "cluster_n",
+        "pix_id_in_cluster",
+        "image",
+    ]
+    for key in expected_keys:
+        assert key in datasource_data, f"Expected key '{key}' not found in datasource"
+
+    # Verify data shapes and content
+    assert len(datasource_data["pix_id"]) == geom.n_pixels
+    assert len(datasource_data["pix_x"]) == geom.n_pixels
+    assert len(datasource_data["pix_y"]) == geom.n_pixels
+    assert len(datasource_data["cluster_n"]) == geom.n_pixels
+    assert len(datasource_data["pix_id_in_cluster"]) == geom.n_pixels
+    assert len(datasource_data["image"]) == geom.n_pixels
+
+    # Verify HoverTool was added to the figure
+    hover_tools = [tool for tool in result.figure.tools if isinstance(tool, HoverTool)]
+    assert len(hover_tools) > 0, "No HoverTool found in figure"
+
+    # Find the custom HoverTool we added
+    custom_hover_tool = None
+    for tool in hover_tools:
+        if len(tool.tooltips) == 6:  # Our custom HoverTool has 6 tooltips
+            custom_hover_tool = tool
+            break
+
+    assert (
+        custom_hover_tool is not None
+    ), "Custom HoverTool with expected tooltips not found"
+
+    # Verify HoverTool has the expected tooltips
+    tooltip_fields = [tooltip[0] for tooltip in custom_hover_tool.tooltips]
+    expected_tooltip_fields = [
+        "pix id",
+        "pix # in cluster",
+        "cluster #",
+        "pix x pos",
+        "pix y pos",
+        "value",
+    ]
+    assert tooltip_fields == expected_tooltip_fields

--- a/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
@@ -3,8 +3,8 @@ import numpy as np
 # bokeh imports
 from bokeh.io import output_file, save
 from bokeh.layouts import column, row
-from bokeh.models import HoverTool, Select, TabPanel, Tabs
-from bokeh.plotting import curdoc
+from bokeh.models import ColumnDataSource, HoverTool, Select, TabPanel, Tabs
+from bokeh.plotting import curdoc, figure
 
 # ctapipe imports
 from ctapipe.coordinates import EngineeringCameraFrame
@@ -355,3 +355,41 @@ def test_compile_hover_tool():
         "value",
     ]
     assert tooltip_fields == expected_tooltip_fields
+
+
+def test_compile_hover_tool_val_vs_id():
+    from nectarchain.dqm.bokeh_app.app_hooks import compile_hover_tool_val_vs_id
+
+    fig = figure()
+    data_source = ColumnDataSource(
+        data=dict(pix_id=np.arange(10), value=np.random.normal(size=10))
+    )
+    scatter = fig.scatter(x="pix_id", y="value", source=data_source)
+
+    result = compile_hover_tool_val_vs_id(pixel_data=scatter, figure=fig)
+
+    assert result is fig
+
+    # Verify HoverTool was added to the figure
+    hover_tools = [tool for tool in result.tools if isinstance(tool, HoverTool)]
+    assert len(hover_tools) > 0, "No HoverTool found in figure"
+
+    # Find the custom HoverTool we added
+    custom_hover_tool = None
+    for tool in hover_tools:
+        if len(tool.tooltips) == 1:
+            custom_hover_tool = tool
+            break
+
+    assert (
+        custom_hover_tool is not None
+    ), "Custom HoverTool with expected tooltip not found"
+
+    # Verify the tooltip is correct
+    tooltip_label = custom_hover_tool.tooltips[0][0]
+    tooltip_value = custom_hover_tool.tooltips[0][1]
+    assert tooltip_label == "(pix_id, value)"
+    assert tooltip_value == "(@pix_id, @value)"
+
+    # Verify the scatter plot is in the renderers
+    assert scatter in custom_hover_tool.renderers


### PR DESCRIPTION
This PR adds detailed HoverTools both for camera display plots and the corresponding scatter plots. The tools are defined separately in dedicated functions. Unit tests for the newly defined functions are also created, and they pass in local. 