### PR TITLE
Enable caching mechanism in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
   NUMBA_NUM_THREADS: 1
   MPLBACKEND: Agg
   PYTEST_ADDOPTS: --color=yes
+  XDG_CACHE_HOME: "${{ github.workspace }}/.cache"
+  CTAPIPE_CACHE: "${{ github.workspace }}/.cache/ctapipe"
 
 jobs:
   lint:
@@ -37,6 +39,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: lint
     strategy:
+      # here until the issues downloading from the DESY server are resolved
+      # we'd actually want to fail fast usually, but with the recurring failures with the
+      # test data server it becomes essentially impossible to get a green CI run if a
+      # failing job cancels all others.
+      fail-fast: false
       matrix:
         include:
           - os: "ubuntu-latest"
@@ -96,6 +103,26 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
+
+      - name: Ensure astropy and ctapipe cache dir
+        run: |
+          mkdir -p $XDG_CACHE_HOME/astropy
+          mkdir -p $CTAPIPE_CACHE
+
+      - name: restore cache data
+        id: cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            .cache/ctapipe
+            .cache/astropy
+          key: ctapipe-test-data-desy
+          restore-keys: |
+            ctapipe-test-data-desy
+
+      - name: debug caches
+        run: |
+          find .cache
 
       - name: Setup xvfb for X11 display
         if: matrix.os == 'ubuntu-latest'
@@ -171,6 +198,17 @@ jobs:
         if: contains(matrix.extra-args, 'codecov')
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: cache data
+        # make sure the largest test job uploads the cached data
+        if: contains(matrix.extra-args, 'codecov')
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            .cache/ctapipe
+            .cache/astropy
+          key: ctapipe-test-data-desy-${{ github.run_id }}-${{ github.run_attempt }}
+
 
       # - name: Start SSH Debugging Session
       #   if: ${{ failure() }}


### PR DESCRIPTION
This PR attempts to solve the ongoing issue with failing jobs in CI, due to timeouts from the test data server at DESY.

Following a discussion with @maxnoe on Slack (many thanks, @maxnoe !), these timeouts are in fact due to recent changes in the IT infrastructure at DESY, which firewall now flags these frequent request from GitHub as DDOS attacks.

To avoid this, this PR introduces a caching mechanism, as implemented in [`ctapipe`](https://github.com/cta-observatory/ctapipe/blob/a9ca611554d452acbb3c3e409707d1cf65bd0217/.github/workflows/ci.yml#L116-L125).