### PR TITLE
Adapt parsing of DQM FITS output

### DIFF
--- a/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
+++ b/src/nectarchain/user_scripts/jlenain/parse_dqm_fits_file.py
@@ -115,10 +115,19 @@ for run in args.runs:
 
     for h in range(1, len(hdu)):
         extname = hdu[h].header["EXTNAME"]
+        xtension = hdu[extname].header["XTENSION"]
         outdict[extname] = dict()
-        for i in range(hdu[extname].header["TFIELDS"]):
-            keyname = hdu[extname].header[f"TTYPE{i+1}"]
-            outdict[extname][keyname] = hdu[extname].data[keyname]
+        if xtension == "BINTABLE":
+            for i in range(hdu[extname].header["TFIELDS"]):
+                keyname = hdu[extname].header[f"TTYPE{i+1}"]
+                outdict[extname][keyname] = hdu[extname].data[keyname]
+        elif xtension == "IMAGE":
+            outdict[extname][extname] = hdu[extname].data
+        else:
+            log.warning(
+                f"I do not know how to parse FITS extension {xtension}, "
+                f"please teach me !"
+            )
 
     try:
         db = DQMDB(read_only=False)


### PR DESCRIPTION
This PR tries to fix #334 .

At the moment, though, this implies the DQM Bokeh app fails with:

```python
File '_renderer.py', line 300, in _process_sequence_literals:
raise RuntimeError(f"Columns need to be 1D ({var} is not)") Traceback (most recent call last):
  File "/opt/conda/envs/nectar-dev/lib/python3.11/site-packages/bokeh/application/handlers/code_runner.py", line 229
, in run
    exec(self._code, module.__dict__)
  File "/opt/cta/nectarchain/src/nectarchain/dqm/bokeh_app/main.py", line 243, in <module>
    page_layout, run_select = get_layout_per_camera(db, runs, cam)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cta/nectarchain/src/nectarchain/dqm/bokeh_app/main.py", line 128, in get_layout_per_camera
    waveforms = make_waveforms(source, runid)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cta/nectarchain/src/nectarchain/dqm/bokeh_app/app_hooks.py", line 223, in make_waveforms
    waveforms[parentkey][childkey].line(
  File "/opt/conda/envs/nectar-dev/lib/python3.11/site-packages/bokeh/plotting/_decorators.py", line 88, in wrapped
    return create_renderer(glyphclass, self.plot, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nectar-dev/lib/python3.11/site-packages/bokeh/plotting/_renderer.py", line 96, in create_renderer
    incompatible_literal_spec_values += _process_sequence_literals(glyphclass, kwargs, source, is_user_source)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/nectar-dev/lib/python3.11/site-packages/bokeh/plotting/_renderer.py", line 300, in _process_sequence_literals
    raise RuntimeError(f"Columns need to be 1D ({var} is not)")
RuntimeError: Columns need to be 1D (y is not)
```