### PR TITLE
Optimise performance DQM trigger statistics

### DIFF
--- a/src/nectarchain/dqm/dqm_summary_processor.py
+++ b/src/nectarchain/dqm/dqm_summary_processor.py
@@ -82,6 +82,11 @@ class DQMSummary:
 
             hdu = fits.BinTableHDU(data)
 
+        # Handle astropy Table objects directly
+        elif isinstance(content, Table):
+            # Content is already a Table, use it as the HDU data
+            hdu = fits.BinTableHDU(content, name=name)
+
         # content can be a float, need to be recast to an array
         else:
             data = Table(np.array([content]))

--- a/src/nectarchain/dqm/start_dqm.py
+++ b/src/nectarchain/dqm/start_dqm.py
@@ -98,6 +98,12 @@ def main():
         type=int,
         help="Maximum number of events to loop through in each run slice",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Allows verbose TQDM for loops",
+    )
     parser.add_argument("-i", "--input-files", nargs="+", help="Local input files")
     parser.add_argument("--log", default="info", help="debug output", type=str)
 
@@ -246,11 +252,18 @@ def main():
     for p in processors:
         p.configure_for_run(path, Pix, Samp, reader1, **charges_kwargs)
 
-    for evt in tqdm(
-        reader, total=args.max_events if args.max_events else len(reader), unit="ev"
-    ):
+    start_read = time.time()
+    looping_over = (
+        tqdm(
+            reader, total=args.max_events if args.max_events else len(reader), unit="ev"
+        )
+        if args.verbose
+        else reader
+    )
+    for evt in looping_over:
         for p in processors:
             p.process_event(evt, noped)
+    read_time = time.time() - start_read
 
     # for the rest of the event files
     for arg in args.input_files[1:]:
@@ -260,24 +273,35 @@ def main():
         with EventSource(
             input_url=path2, config=config, max_events=args.max_events
         ) as reader:
-            for evt in tqdm(
-                reader,
-                total=args.max_events if args.max_events else len(reader),
-                unit="ev",
-            ):
+            looping_over = (
+                tqdm(
+                    reader,
+                    total=args.max_events if args.max_events else len(reader),
+                    unit="ev",
+                )
+                if args.verbose
+                else reader
+            )
+            for evt in looping_over:
                 for p in processors:
                     p.process_event(evt, noped)
 
+    start_finish = time.time()
     for p in processors:
         p.finish_run()
+    finish_time = time.time() - start_finish
 
+    start_results = time.time()
     dict_num = 0
     for p in processors:
         NESTED_DICT[NESTED_DICT_KEYS[dict_num]] = p.get_results()
         dict_num += 1
+    results_time = time.time() - start_results
 
+    start_write = time.time()
     # Write all results in 1 fits file:
     p.write_all_results(ResPath, NESTED_DICT)
+    write_time = time.time() - start_write
     if args.write_db:
         db = DQMDB(read_only=False)
         if db.insert(name, NESTED_DICT):
@@ -287,18 +311,23 @@ def main():
 
     # if plot option in arguments, it will construct the figures and save them
     if PlotFig:
+        figures_to_save = []
         for p in processors:
-            processor_figure_dict, processor_figure_name_dict = p.plot_results(
-                name, fig_path
-            )
+            fig_dict, name_dict = p.plot_results(name, fig_path)
+            figures_to_save.extend(zip(fig_dict.values(), name_dict.values()))
 
-            for fig_plot in processor_figure_dict:
-                fig = processor_figure_dict[fig_plot]
-                SavePath = processor_figure_name_dict[fig_plot]
-                fig.savefig(SavePath)
-                plt.close()
+        # Save all at once (matplotlib can parallelize I/O)
+        for fig, path in figures_to_save:
+            fig.savefig(path)
+            plt.close(fig)
 
     end = time.time()
+    log.info(
+        f"Read: {read_time:.2f}s, "
+        + f"Finish: {finish_time:.2f}s, "
+        + f"Results: {results_time:.2f}s, "
+        + f"Write: {write_time:.2f}s"
+    )
     log.info(f"Processing time: {end-start:.2f} s.")
 
 

--- a/src/nectarchain/dqm/trigger_statistics.py
+++ b/src/nectarchain/dqm/trigger_statistics.py
@@ -69,80 +69,86 @@ class TriggerStatistics(DQMSummary):
         # self.run_start = np.min(self.event_times)
         self.run_end = np.max(self.event_times)
 
-        self.event_ped_times = self.event_times[
-            self.event_type == EventType.SKY_PEDESTAL.value
-        ]
+        # First, save wrong times (events before run_start) from unfiltered data
+        is_wrong = self.event_times < self.run_start
+        self.event_wrong_times = self.event_times[is_wrong]
+
+        # Filter by run_start - only keep events after run_start
+        valid = self.event_times > self.run_start
+        self.event_id = self.event_id[valid]
+        self.event_times = self.event_times[valid]
+        self.event_type = self.event_type[valid]
+
+        # Compute masks for subsets on the filtered arrays
+        self._ped_mask = self.event_type == EventType.SKY_PEDESTAL.value
         # sky pedestal, event id 2
-        self.event_phy_times = self.event_times[
-            self.event_type == EventType.SUBARRAY.value
-        ]
+        self._phy_mask = self.event_type == EventType.SUBARRAY.value
         # standard physics stereo, event id 32
         # TODO: add ids and event time selection for
         # other event types, e.g., dark pedestals
-
-        mask = (self.event_type != EventType.SUBARRAY.value) & (
-            self.event_type != EventType.SKY_PEDESTAL.value
-        )
-        self.event_other_times = self.event_times[mask]
-
-        self.event_ped_id = self.event_id[
-            self.event_type == EventType.SKY_PEDESTAL.value
-        ]
-        self.event_phy_id = self.event_id[self.event_type == EventType.SUBARRAY.value]
-        self.event_other_id = self.event_id[mask]
-
-        self.event_ped_id = self.event_ped_id[self.event_ped_times > self.run_start]
-        self.event_phy_id = self.event_phy_id[self.event_phy_times > self.run_start]
-        self.event_other_id = self.event_other_id[
-            self.event_other_times > self.run_start
-        ]
-        self.event_ped_times = self.event_ped_times[
-            self.event_ped_times > self.run_start
-        ]
-        self.event_phy_times = self.event_phy_times[
-            self.event_phy_times > self.run_start
-        ]
-        self.event_other_times = self.event_other_times[
-            self.event_other_times > self.run_start
-        ]
-        self.event_wrong_times = self.event_times[self.event_times < self.run_start]
-
-        self.event_id = self.event_id[self.event_times > self.run_start]
-        self.event_times = self.event_times[self.event_times > self.run_start]
+        self._other_mask = ~self._ped_mask & ~self._phy_mask
 
     def get_results(self):
         self.TriggerStat_Results_Dict["TRIGGER-TYPES"] = self.triggers
+
+        # Count using masks (no array creation)
+        n_ped = self._ped_mask.sum()
+        n_phy = self._phy_mask.sum()
+        n_other = self._other_mask.sum()
+
         self.TriggerStat_Results_Dict["TRIGGER-STATISTICS"] = {
             "All": [len(self.event_times)],
-            "Physical": [len(self.event_phy_times)],
-            "Pedestals": [len(self.event_ped_times)],
-            "Others": [len(self.event_other_times)],
+            "Physical": [n_phy],
+            "Pedestals": [n_ped],
+            "Others": [n_other],
             "Wrong times": [len(self.event_wrong_times)],
         }
 
-        self.TriggerStat_Results_Dict["TRIGGER-EVENTS-ALL"] = {
-            "Timestamps": self.event_times,
-            "IDs": self.event_id,
-        }
-        if len(self.event_phy_times) > 0:
-            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-PHY"] = {
-                "Timestamps": self.event_phy_times,
-                "IDs": self.event_phy_id,
+        from astropy.table import Table
+
+        # Use masks directly on main arrays - no intermediate copies
+        # ALL events
+        self.TriggerStat_Results_Dict["TRIGGER-EVENTS-ALL"] = Table(
+            {
+                "Timestamps": self.event_times,
+                "IDs": self.event_id,
             }
-        if len(self.event_ped_times) > 0:
-            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-PED"] = {
-                "Timestamps": self.event_ped_times,
-                "IDs": self.event_ped_id,
-            }
-        if len(self.event_other_times) > 0:
-            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-OTHERS"] = {
-                "Timestamps": self.event_other_times,
-                "IDs": self.event_other_id,
-            }
+        )
+
+        # PHY events
+        if n_phy > 0:
+            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-PHY"] = Table(
+                {
+                    "Timestamps": self.event_times[self._phy_mask],
+                    "IDs": self.event_id[self._phy_mask],
+                }
+            )
+
+        # PED events
+        if n_ped > 0:
+            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-PED"] = Table(
+                {
+                    "Timestamps": self.event_times[self._ped_mask],
+                    "IDs": self.event_id[self._ped_mask],
+                }
+            )
+
+        # OTHERS events
+        if n_other > 0:
+            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-OTHERS"] = Table(
+                {
+                    "Timestamps": self.event_times[self._other_mask],
+                    "IDs": self.event_id[self._other_mask],
+                }
+            )
+
+        # WRONG times (only has Timestamps, no IDs)
         if len(self.event_wrong_times) > 0:
-            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-WRONG"] = {
-                "Timestamps": self.event_wrong_times,
-            }
+            self.TriggerStat_Results_Dict["TRIGGER-EVENTS-WRONG"] = Table(
+                {
+                    "Timestamps": self.event_wrong_times,
+                }
+            )
 
         self.TriggerStat_Results_Dict["START-TIMES"] = {
             "Run start time": [self.run_start1],
@@ -202,32 +208,33 @@ class TriggerStatistics(DQMSummary):
             label="All events (%s + %s invisible)"
             % (len(self.event_times), len(self.event_wrong_times)),
         )
+        # Use masks directly on main arrays
         ax.hist(
-            self.event_phy_times - self.run_start,
+            self.event_times[self._phy_mask] - self.run_start,
             n,
             color="cyan",
             linewidth=1,
             log=True,
             alpha=0.5,
-            label="Physical events (%s)" % len(self.event_phy_times),
+            label="Physical events (%s)" % self._phy_mask.sum(),
         )
         ax.hist(
-            self.event_ped_times - self.run_start,
+            self.event_times[self._ped_mask] - self.run_start,
             n,
             color="orange",
             linewidth=1,
             log=True,
             alpha=0.5,
-            label="Pedestal events (%s)" % len(self.event_ped_times),
+            label="Pedestal events (%s)" % self._ped_mask.sum(),
         )
         ax.hist(
-            self.event_other_times - self.run_start,
+            self.event_times[self._other_mask] - self.run_start,
             n,
             color="brown",
             linewidth=1,
             log=True,
             alpha=0.5,
-            label="Other events (%s)" % len(self.event_other_times),
+            label="Other events (%s)" % self._other_mask.sum(),
         )
         plt.legend(loc="upper right")
         plt.xlabel("Time")
@@ -253,32 +260,33 @@ class TriggerStatistics(DQMSummary):
             alpha=0.5,
             label="All events (%s)" % len(self.event_id),
         )
+        # Use masks directly on main arrays
         ax.hist(
-            self.event_phy_id,
+            self.event_id[self._phy_mask],
             n,
             color="orange",
             linewidth=1,
             log=True,
             alpha=0.5,
-            label="Physical events (%s)" % len(self.event_phy_id),
+            label="Physical events (%s)" % self._phy_mask.sum(),
         )
         ax.hist(
-            self.event_ped_id,
+            self.event_id[self._ped_mask],
             n,
             color="cyan",
             linewidth=1,
             log=True,
             alpha=0.5,
-            label="Pedestal events (%s)" % len(self.event_ped_id),
+            label="Pedestal events (%s)" % self._ped_mask.sum(),
         )
         ax.hist(
-            self.event_other_id,
+            self.event_id[self._other_mask],
             n,
             color="brown",
             linewidth=1,
             log=True,
             alpha=0.5,
-            label="Other events (%s)" % len(self.event_other_id),
+            label="Other events (%s)" % self._other_mask.sum(),
         )
         plt.legend(loc="upper right")
         plt.xlabel("ID")


### PR DESCRIPTION
perf(src/nectarchain/dqm):
- trigger_statistics.py: several improvements in finish_run and get_results to create as few arrays as possible and return directly astropy Table
- dqm_summary_processor.py: include if clause for create_hdu for astropy Table
- start_dqm.py: optional tqdm, more efficient figures saving, logging times for several steps of the processor

This PR slightly optimises the performance of the `trigger_statistics.py` processor by saving a few seconds of computation. However, I believe this is not the processor from which we will save the most time, as there are not tight numerical loops that can be optimised with numba, not much more that can be vectorised or made faster with numpy arrays, and multiprocessing is not implemented yet. We'll probably optimise much more in the other, more computationally heavy, processors. Following this PR, there will be others optimising each processor.