### PR TITLE
Fix unphysically large values in the waveforms DQM processor

### DIFF
--- a/src/nectarchain/dqm/waveforms.py
+++ b/src/nectarchain/dqm/waveforms.py
@@ -108,12 +108,12 @@ class WaveFormsHighLowGain(DQMSummary):
         if self.counter_evt > 0:
             self.wf_average = self.wf / self.counter_evt  # get average
             # get average over pixels
-            self.wf_mean_over_pix = np.mean(self.wf_average, axis=0)
+            self.wf_mean_over_pix = np.nanmean(self.wf_average, axis=0)
 
         if self.counter_ped > 0:
             # get average pedestals
             self.wf_ped_average = self.wf_ped / self.counter_ped
-            self.wf_ped_mean_over_pix = np.mean(self.wf_ped_average, axis=0)
+            self.wf_ped_mean_over_pix = np.nanmean(self.wf_ped_average, axis=0)
 
         return None
 


### PR DESCRIPTION
This PR tries to fix #339 . I am not sure this is enough, but at least, reading a DQM FITS file back gives:

```python
from astropy.io import fits
hdr = fits.open("NectarCAM_Run7213_Results.fits")
hdr["WF-PHY-AVERAGE-PIX-LOW-GAIN"].data
FITS_rec([(inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,), (inf,),
          (inf,), (inf,), (inf,), (inf,)],
         dtype=(numpy.record, [('WF-PHY-AVERAGE-PIX-LOW-GAIN', '>f8')]))
```
which correctly flags these values as `inf` instead of unphysically large floats.