### PR TITLE
Small bugfix in calibration pipeline tool

### DIFF
--- a/src/nectarchain/makers/calibration/calibration_pipeline.py
+++ b/src/nectarchain/makers/calibration/calibration_pipeline.py
@@ -789,9 +789,9 @@ class PipelineNectarCAMCalibrationTool(NectarCAMCalibrationTool):
         self._ctapipe_containers["calibration"].n_pe[HIGH_GAIN, mask[HIGH_GAIN]] = (
             1 / GAIN_DEFAULT
         )
-        self._ctapipe_containers["calibration"].n_pe[
-            LOW_GAIN, mask[LOW_GAIN]
-        ] *= HILO_DEFAULT
+        self._ctapipe_containers["calibration"].n_pe[LOW_GAIN, mask[LOW_GAIN]] = (
+            HILO_DEFAULT / GAIN_DEFAULT
+        )
 
         # Set default flatfield values
         self._ctapipe_containers["calibration"].dc_to_pe[mask] = (

--- a/src/nectarchain/user_scripts/pcorrea/example_pipeline.py
+++ b/src/nectarchain/user_scripts/pcorrea/example_pipeline.py
@@ -66,7 +66,7 @@ SPE_HHV_result_path = Path(
 )
 
 # Output format of cat-A calibration file (.h5, .fits, .fits.gz)
-output_format = ".h5"
+output_format = ".fits"
 
 # Option to save the individual outputs of each tool
 save_tmp = True
@@ -110,6 +110,7 @@ config[FF_tool_name].window_shift = 4
 SPE_HHV_tool_default_name = FlatFieldSPEHHVNectarCAMCalibrationTool.__name__
 
 
+# NOTE: this is for NectarCAMQM
 def set_SPE_HHV_tool_default_config(
     config, SPE_HHV_tool_default_name=SPE_HHV_tool_default_name
 ):


### PR DESCRIPTION
Corrected a bug regarding default values of the low gain. Also made the example script yield a `.fits` output file by default. 