### PR TITLE
Drop support for python 3.10 and 3.11, bump python prod version to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.12"
       - name: Runs pre-commit hooks
         uses: pre-commit/action@v3.0.1
         with:
@@ -54,27 +54,15 @@ jobs:
             python-version: "3.12"
             ctapipe-version: "v0.24.0"
             install-method: "pip"
-          - os: "ubuntu-latest"
-            python-version: "3.13"
-            ctapipe-version: "v0.24.0"
-            install-method: "mamba"
-          - os: "ubuntu-latest"
-            python-version: "3.14"
-            ctapipe-version: "v0.24.0"
-            install-method: "mamba"
-          - os: "ubuntu-latest"
-            python-version: "3.14"
-            ctapipe-version: "v0.24.0"
-            install-method: "pip"
             extra-args: ["codecov"]
           # macos 15 image, x86-based
           - os: "macos-15-intel"
-            python-version: "3.14"
+            python-version: "3.12"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"
           # macos 14 image is arm64 based
           - os: "macos-14"
-            python-version: "3.14"
+            python-version: "3.12"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"
 
@@ -230,7 +218,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: 3.12
 
       - name: Install dependencies for Qt 5 on Ubuntu
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,18 +149,7 @@ jobs:
           pip install \
              "git+https://github.com/cta-observatory/ctapipe@$CTAPIPE_VERSION"
 
-          if [ "${{ matrix.os }}" == "macos-14" ]; then
-            # nectarchain installation with pip
-            if [ "${{ matrix.install-method }}" == "pip" ]; then
-              pip install -e .
-            else
-              pip install --no-deps -e .
-            fi
-            python -c "import tomllib, sys; print('\n'.join(tomllib.load('pyproject.toml')['project']['optional-dependencies']['test']))" | xargs pip install 
-          else
-            echo "pip install -e ."
-            pip install -e .[test]
-          fi
+          pip install -e .[test]
 
       - name: Check pyqt version and installation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Runs pre-commit hooks
         uses: pre-commit/action@v3.0.1
         with:
@@ -47,30 +47,34 @@ jobs:
       matrix:
         include:
           - os: "ubuntu-latest"
-            python-version: "3.10"
+            python-version: "3.12"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"
           - os: "ubuntu-latest"
-            python-version: "3.10"
+            python-version: "3.12"
             ctapipe-version: "v0.24.0"
             install-method: "pip"
           - os: "ubuntu-latest"
-            python-version: "3.11"
+            python-version: "3.13"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"
           - os: "ubuntu-latest"
-            python-version: "3.11"
+            python-version: "3.14"
+            ctapipe-version: "v0.24.0"
+            install-method: "mamba"
+          - os: "ubuntu-latest"
+            python-version: "3.14"
             ctapipe-version: "v0.24.0"
             install-method: "pip"
             extra-args: ["codecov"]
           # macos 15 image, x86-based
           - os: "macos-15-intel"
-            python-version: "3.11"
+            python-version: "3.14"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"
           # macos 14 image is arm64 based
           - os: "macos-14"
-            python-version: "3.11"
+            python-version: "3.14"
             ctapipe-version: "v0.24.0"
             install-method: "mamba"
 
@@ -164,9 +168,7 @@ jobs:
             else
               pip install --no-deps -e .
             fi
-            # install with pip dependencies for pytest (NB : when we will use python > 3.10 for all configs, use tomllib instead of toml)
-            pip install toml
-            python -c "import toml, sys; print('\n'.join(toml.load('pyproject.toml')['project']['optional-dependencies']['test']))" | xargs pip install 
+            python -c "import tomllib, sys; print('\n'.join(tomllib.load('pyproject.toml')['project']['optional-dependencies']['test']))" | xargs pip install 
           else
             echo "pip install -e ."
             pip install -e .[test]
@@ -228,7 +230,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.14
 
       - name: Install dependencies for Qt 5 on Ubuntu
         run: |

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.14
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black-jupyter
   # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: [--max-line-length=88, "--extend-ignore=E203,E712"]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.14"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.14"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,8 @@ extensions = [
     "sphinx_qt_documentation",
 ]
 
+suppress_warnings = ["misc.copy_overwrite"]
+
 autosummary_generate = True  # Turn on sphinx.ext.autosummary
 autoclass_content = "both"  # Add __init__ doc (ie. params) to class summaries
 html_show_sourcelink = (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,15 +7,10 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import datetime
 import os
-import sys
+import tomllib
 from pathlib import Path
 
 import nectarchain
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
 pyproject = tomllib.loads(pyproject_path.read_text())
@@ -92,7 +87,7 @@ autodoc_mock_imports = [
 
 # intersphinx allows referencing other packages sphinx docs
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.11", None),
+    "python": ("https://docs.python.org/3.14", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ autodoc_mock_imports = [
 
 # intersphinx allows referencing other packages sphinx docs
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.14", None),
+    "python": ("https://docs.python.org/3.12", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),

--- a/docs/user-guide/getting-started.rst
+++ b/docs/user-guide/getting-started.rst
@@ -48,7 +48,7 @@ Using ``pip``
 
 .. code-block:: console
 
-   $ mamba create -n nectarchain python=3.14
+   $ mamba create -n nectarchain python=3.12
    $ mamba activate nectarchain
    $ pip install nectarchain
 

--- a/docs/user-guide/getting-started.rst
+++ b/docs/user-guide/getting-started.rst
@@ -48,7 +48,7 @@ Using ``pip``
 
 .. code-block:: console
 
-   $ mamba create -n nectarchain python=3.11
+   $ mamba create -n nectarchain python=3.14
    $ mamba activate nectarchain
    $ pip install nectarchain
 
@@ -56,7 +56,7 @@ To install a specific version of ``nectarchain``, you can use the following comm
 
 .. code-block:: console
 
-   $ pip install nectarchain==0.1.8
+   $ pip install nectarchain==0.3.2
 
 .. _as-a-container:
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.14
+  - python=3.12
   - ctapipe=0.24
   - ctapipe-io-nectarcam>0.1
   - jinja2

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.14
   - ctapipe=0.24
   - ctapipe-io-nectarcam>0.1
   - jinja2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14"
+    "Programming Language :: Python :: 3.12"
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "ctapipe~=0.24",
     "ctapipe-io-nectarcam>0.1",
@@ -35,7 +36,6 @@ dependencies = [
     "h5py",
     "pyqt5",
     "pyqtgraph",
-    "tomli; python_version < '3.11'",
     "watchdog",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "h5py",
     "pyqt5",
     "pyqtgraph",
+    "setuptools<81",
     "watchdog",
 ]
 


### PR DESCRIPTION
This PR bumps the python version to 3.12 for our production environment for `nectarchain`.

It also removes support for python versions 3.10 and 3.11.

Incidentally, this should also fix #353.

N.B.: we should also propagate the same changes to https://github.com/cta-observatory/ctapipe_io_nectarcam.