### PR TITLE
Display events trigger timestamps vs their ids on the DQM Bokeh app

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -13,6 +13,7 @@ from bokeh.models import (
     ColorBar,
     ColumnDataSource,
     CustomJS,
+    DatetimeTickFormatter,
     HoverTool,
     Label,
     Node,
@@ -218,14 +219,27 @@ def make_trigger_timestamps_vs_ids(source, runid=None):
             trig_timestamps[parentkey] = figure(
                 title=parentkey,
                 x_range=(np.min(evts_ids), np.max(evts_ids)),
-                y_range=(np.min(evts_timestamps), np.max(evts_timestamps)),
+                y_range=(
+                    np.min(evts_timestamps * 1000),
+                    np.max(evts_timestamps * 1000),
+                ),
+                # Convert to ms
+            )
+            trig_timestamps[parentkey].yaxis.formatter = DatetimeTickFormatter(
+                seconds="%H:%M:%S",
+                minutes="%H:%M:%S",
+                hourmin="%H:%M:%S",
+                hours="%H:%M:%S",
+                days="%H:%M:%S",
+                months="%H:%M:%S",
+                years="%H:%M:%S",
             )
             trig_timestamps[parentkey].scatter(
-                x=evts_ids, y=evts_timestamps, size=2, alpha=0.6, color="blue"
+                x=evts_ids, y=evts_timestamps * 1000, size=2, alpha=0.6, color="blue"
             )
             trig_timestamps[parentkey].scatter(
                 x=evts_ids[negative_diff],
-                y=evts_timestamps[negative_diff],
+                y=evts_timestamps[negative_diff] * 1000,
                 size=4,
                 alpha=0.6,
                 color="red",

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -179,6 +179,119 @@ def get_run_times(source):
     return run_start_time_dt, first_event_time_dt, last_event_time_dt
 
 
+def make_trigger_timestamps_vs_ids(source, runid=None):
+    """Make trigger event timestamps plots
+
+    Parameters
+    ----------
+    source : dict
+        Dictionary returned by `get_rundata`
+    runid : str
+        Identifier for dictionary extracted from the database,
+        containing the NectarCAM run number. Example: 'NectarCAMQM_Run6310'.
+        By default None
+
+    Returns
+    -------
+    dict
+        Nested dictionary containing line plots
+        for the trigger event timestamps
+    """
+
+    with open(labels_path, "r", encoding="utf-8") as file:
+        y_axis_labels = json.load(file)["y_axis_labels_trig_timestamps"]
+
+    trig_timestamps = collections.defaultdict(dict)
+    for parentkey in source.keys():
+        if re.match(r"TRIGGER-EVENTS-(?!WRONG).*", parentkey):
+            # TODO: need to understand what we want to do with TRIGGER-EVENTS-WRONG
+            logger.info(f"Run id {runid}, preparing plot for {parentkey}")
+
+            trig_timestamps[parentkey] = figure(title=parentkey)
+
+            evts_ids = source[parentkey]["IDs"]
+            evts_timestamps = source[parentkey]["Timestamps"][np.argsort(evts_ids)]
+            evts_ids = np.sort(evts_ids)
+            evts_diff_timestamps = np.array([0] + np.diff(evts_timestamps).tolist())
+            negative_diff = evts_diff_timestamps < 0
+
+            trig_timestamps[parentkey] = figure(
+                title=parentkey,
+                x_range=(np.min(evts_ids), np.max(evts_ids)),
+                y_range=(np.min(evts_timestamps), np.max(evts_timestamps)),
+            )
+            trig_timestamps[parentkey].scatter(
+                x=evts_ids, y=evts_timestamps, size=2, alpha=0.6, color="blue"
+            )
+            trig_timestamps[parentkey].scatter(
+                x=evts_ids[negative_diff],
+                y=evts_timestamps[negative_diff],
+                size=4,
+                alpha=0.6,
+                color="red",
+                legend_label="# of negative Timestamp[i+1] - Timestamp[i]: "
+                + f"{len(evts_timestamps[negative_diff])}",
+            )
+            trig_timestamps[parentkey].legend.location = "top_left"
+            trig_timestamps[parentkey].xaxis.axis_label = "Event ID"
+
+            try:
+                trig_timestamps[parentkey].yaxis.axis_label = y_axis_labels[parentkey]
+            except ValueError:
+                trig_timestamps[parentkey].yaxis.axis_label = ""
+            except KeyError:
+                trig_timestamps[parentkey].yaxis.axis_label = ""
+
+            trig_timestamps[parentkey].xaxis.axis_label_text_font_size = "12pt"
+            trig_timestamps[parentkey].yaxis.axis_label_text_font_size = "12pt"
+            trig_timestamps[parentkey].xaxis.major_label_text_font_size = "10pt"
+            trig_timestamps[parentkey].yaxis.major_label_text_font_size = "10pt"
+            trig_timestamps[parentkey].xaxis.axis_label_text_font_style = "normal"
+            trig_timestamps[parentkey].yaxis.axis_label_text_font_style = "normal"
+
+    logger.info(f"Successfully created trigger timestamps plots for run {runid}")
+
+    return dict(trig_timestamps)
+
+
+def update_trigger_timestamps_vs_ids(data, runid=None):
+    """Reset each trigger timestamp plot previously
+       created by `make_trigger_timestamps_vs_ids`
+
+    Parameters
+    ----------
+    data : dict
+        Dictionary returned by `get_rundata`
+    runid : str
+        Identifier for dictionary extracted from the database,
+        containing the NectarCAM run number. Example: 'NectarCAMQM_Run6310'.
+        By default None
+
+    Returns
+    -------
+    bokeh.models.TabPanel
+        Updated TabPanel containing the bokeh layout for the trigger timestamp plots
+    """
+
+    # Make new trigger timestamp plots
+    trig_timestamps = make_trigger_timestamps_vs_ids(data, runid)
+
+    list_trig_timestamps = [
+        trig_timestamps[parentkey] for parentkey in trig_timestamps.keys()
+    ]
+
+    layout_trig_timestamps = column(
+        list_trig_timestamps,
+        sizing_mode="scale_width",
+    )
+
+    tab_trig_timestamps = TabPanel(
+        child=layout_trig_timestamps, title="Trigger Timestamps"
+    )
+
+    return tab_trig_timestamps
+
+
 def extract_waveforms_from_source(source):
     """Extract waveforms from the provided run data
 

--- a/src/nectarchain/dqm/bokeh_app/data/labels.json
+++ b/src/nectarchain/dqm/bokeh_app/data/labels.json
@@ -11,6 +11,13 @@
         "CAMERA-BADPIXTIMELINE-PHY-HIGH-GAIN": "Fraction of bad pixels",
         "CAMERA-BADPIXTIMELINE-PHY-LOW-GAIN": "Fraction of bad pixels"
     }, 
+    "y_axis_labels_trig_timestamps": {
+        "TRIGGER-EVENTS-ALL": "Timestamps [MJD]",
+        "TRIGGER-EVENTS-PHY": "Timestamps [MJD]",
+        "TRIGGER-EVENTS-PED": "Timestamps [MJD]",
+        "TRIGGER-EVENTS-OTHERS": "Timestamps [MJD]",
+        "TRIGGER-EVENTS-WRONG": "Timestamps [MJD]"
+    },
     "colorbar_labels_camera_display": {
         "CAMERA-TEMPERATURE-AVERAGE": "$$^{\\circ}$$C",
         "CAMERA-TEMPERATURE-STD": "$$^{\\circ}$$C",

--- a/src/nectarchain/dqm/bokeh_app/data/labels.json
+++ b/src/nectarchain/dqm/bokeh_app/data/labels.json
@@ -12,11 +12,11 @@
         "CAMERA-BADPIXTIMELINE-PHY-LOW-GAIN": "Fraction of bad pixels"
     }, 
     "y_axis_labels_trig_timestamps": {
-        "TRIGGER-EVENTS-ALL": "Timestamps [MJD]",
-        "TRIGGER-EVENTS-PHY": "Timestamps [MJD]",
-        "TRIGGER-EVENTS-PED": "Timestamps [MJD]",
-        "TRIGGER-EVENTS-OTHERS": "Timestamps [MJD]",
-        "TRIGGER-EVENTS-WRONG": "Timestamps [MJD]"
+        "TRIGGER-EVENTS-ALL": "Timestamps [UTC]",
+        "TRIGGER-EVENTS-PHY": "Timestamps [UTC]",
+        "TRIGGER-EVENTS-PED": "Timestamps [UTC]",
+        "TRIGGER-EVENTS-OTHERS": "Timestamps [UTC]",
+        "TRIGGER-EVENTS-WRONG": "Timestamps [UTC]"
     },
     "colorbar_labels_camera_display": {
         "CAMERA-TEMPERATURE-AVERAGE": "$$^{\\circ}$$C",

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -5,9 +5,11 @@ from app_hooks import (
     get_rundata,
     make_camera_displays,
     make_timelines,
+    make_trigger_timestamps_vs_ids,
     make_waveforms,
     update_camera_displays,
     update_timelines,
+    update_trigger_timestamps_vs_ids,
     update_waveforms,
 )
 
@@ -71,6 +73,7 @@ def get_layout_per_camera(source, runids, camera_code):
         tab_camera_displays = update_camera_displays(source, runid)
         tab_timelines = update_timelines(source, runid)
         tab_waveforms = update_waveforms(source, runid)
+        tab_trig_timestamps = update_trigger_timestamps_vs_ids(source, runid)
         run_start_time_dt, first_event_time_dt, last_event_time_dt = get_run_times(
             source
         )
@@ -93,7 +96,12 @@ def get_layout_per_camera(source, runids, camera_code):
 
         # Combine panels into tabs
         tabs = Tabs(
-            tabs=[tab_camera_displays, tab_timelines, tab_waveforms],
+            tabs=[
+                tab_camera_displays,
+                tab_timelines,
+                tab_waveforms,
+                tab_trig_timestamps,
+            ],
             sizing_mode="scale_width",
         )
 
@@ -126,6 +134,7 @@ def get_layout_per_camera(source, runids, camera_code):
     displays = make_camera_displays(source, runid)
     timelines = make_timelines(source, runid)
     waveforms = make_waveforms(source, runid)
+    trig_timestamps = make_trigger_timestamps_vs_ids(source, runid)
 
     run_start_time_dt, first_event_time_dt, last_event_time_dt = get_run_times(source)
     run_times_string = Div(
@@ -180,6 +189,10 @@ def get_layout_per_camera(source, runids, camera_code):
         for childkey in waveforms[parentkey].keys()
     ]
 
+    list_trig_timestamps = [
+        trig_timestamps[parentkey] for parentkey in trig_timestamps.keys()
+    ]
+
     layout_camera_displays = column(
         camera_displays,
         sizing_mode="scale_width",
@@ -195,6 +208,11 @@ def get_layout_per_camera(source, runids, camera_code):
         sizing_mode="scale_width",
     )
 
+    layout_trig_timestamps = column(
+        list_trig_timestamps,
+        sizing_mode="scale_width",
+    )
+
     # Create different tabs
     tab_camera_displays = TabPanel(
         child=layout_camera_displays, title="Camera displays"
@@ -203,9 +221,13 @@ def get_layout_per_camera(source, runids, camera_code):
 
     tab_waveforms = TabPanel(child=layout_waveforms, title="Waveforms")
 
+    tab_trig_timestamps = TabPanel(
+        child=layout_trig_timestamps, title="Trigger Timestamps"
+    )
+
     # Combine panels into tabs
     tabs = Tabs(
-        tabs=[tab_camera_displays, tab_timelines, tab_waveforms],
+        tabs=[tab_camera_displays, tab_timelines, tab_waveforms, tab_trig_timestamps],
         sizing_mode="scale_width",
     )
 

--- a/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
@@ -37,6 +37,14 @@ test_dict = {
                 [0, 1, 2] + [0] * (geom.n_pixels - 3)
             ),
         },
+        "TRIGGER-EVENTS-PHY": {
+            "Timestamps": np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            "IDs": np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        },
+        "TRIGGER-EVENTS-PED": {
+            "Timestamps": np.array([2, 1, 3, 4, 5, 7, 6, 8, 9, 10]),
+            "IDs": np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        },
     }
 }
 # Renders the second image incomplete
@@ -130,6 +138,13 @@ def test_make_waveforms():
         make_waveforms(source=test_dict[runid], runid=runid)
 
 
+def test_make_trigger_timestamps_vs_ids():
+    from nectarchain.dqm.bokeh_app.app_hooks import make_trigger_timestamps_vs_ids
+
+    for runid in list(test_dict.keys()):
+        make_trigger_timestamps_vs_ids(source=test_dict[runid], runid=runid)
+
+
 def test_get_run_ids_for_camera():
     from nectarchain.dqm.bokeh_app.app_hooks import get_run_ids_for_camera
 
@@ -210,6 +225,7 @@ def test_bokeh(tmp_path):
         get_rundata,
         make_camera_displays,
         make_timelines,
+        make_trigger_timestamps_vs_ids,
         make_waveforms,
     )
 
@@ -229,6 +245,7 @@ def test_bokeh(tmp_path):
     displays = make_camera_displays(source, runid)
     timelines = make_timelines(source, runid)
     waveforms = make_waveforms(source, runid)
+    trig_timestamps = make_trigger_timestamps_vs_ids(source, runid)
 
     camera_displays = [
         column(
@@ -259,6 +276,10 @@ def test_bokeh(tmp_path):
         for childkey in waveforms[parentkey].keys()
     ]
 
+    list_trig_timestamps = [
+        trig_timestamps[parentkey] for parentkey in trig_timestamps.keys()
+    ]
+
     layout_camera_displays = column(
         camera_displays,
         sizing_mode="scale_width",
@@ -274,6 +295,11 @@ def test_bokeh(tmp_path):
         sizing_mode="scale_width",
     )
 
+    layout_trig_timestamps = column(
+        list_trig_timestamps,
+        sizing_mode="scale_width",
+    )
+
     # Create different tabs
     tab_camera_displays = TabPanel(
         child=layout_camera_displays, title="Camera displays"
@@ -282,9 +308,13 @@ def test_bokeh(tmp_path):
 
     tab_waveforms = TabPanel(child=layout_waveforms, title="Waveforms")
 
+    tab_trig_timestamps = TabPanel(
+        child=layout_trig_timestamps, title="Trigger Timestamps"
+    )
+
     # Combine panels into tabs
     tabs = Tabs(
-        tabs=[tab_camera_displays, tab_timelines, tab_waveforms],
+        tabs=[tab_camera_displays, tab_timelines, tab_waveforms, tab_trig_timestamps],
         sizing_mode="scale_width",
     )
 


### PR DESCRIPTION
feat(src/nectarchain/dqm/bokeh_app):
- data/labels.json: add y-axis labels for trigger events timestamps
- app_hooks.py: add make_trigger_timestamps_vs_ids to make plots for timestamps vs event ids, and update_trigger_timestamps_vs_ids to work with the run selection update
- main.py: adapt layout with additional tab for the newly created plots
- tests/test_app_hooks.py: add tests
 
This PR addresses part of the additions to the Bokeh app which were discussed during the on-site coding sprint. In particular, it adds a tab with the trigger event timestamp vs id information, checking if the timestamps are correctly growing with time (so both the timestamps and the event ids are growing). If negative Timestamp[i+1] - Timestamp[i] are found, they are shown by overplotting red points on the blue ones. Moreover, the legend shows the count of how many negative timestamp differences are found.
We could envision adding a Div with another PR listing all the event timestamps and ids for which negative differences were found.

<img width="626" height="602" alt="image" src="https://github.com/user-attachments/assets/5a69fb1c-7f85-4de8-bd64-7b32472341c5" />
