### PR TITLE
Fix leftover old obsolete argument in Bokeh make_camera_display 

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -666,7 +666,7 @@ def update_camera_displays(camera_displays_data, runid=None):
     return tab_camera_displays
 
 
-def make_pixel_vals_histo(source, parent_key, child_key):
+def make_pixel_vals_histo(camera_displays_data, parent_key, child_key):
     """Make histograms of pixel values
        to fill the nested dict
        created by `make_camera_displays`
@@ -675,8 +675,10 @@ def make_pixel_vals_histo(source, parent_key, child_key):
 
     Parameters
     ----------
-    source : dict
-        Dictionary returned by `get_rundata`
+    camera_displays_data : dict
+        Dictionary containing camera display data extracted from source.
+        Each value is a dict with child keys containing 2D image arrays.
+        This should also include BADPIX data which is needed for masking.
     parent_key : str
         Parent key to extract quantity from the dict
     child_key : str
@@ -688,14 +690,14 @@ def make_pixel_vals_histo(source, parent_key, child_key):
         figure containing the histogram of pixel values
     """
 
-    image = np.nan_to_num(source[parent_key][child_key], nan=0.0)
+    image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
 
     if "BADPIX" in parent_key:
         image = set_bad_pixels_cap_value(image)
         data_for_hist = image
     else:
         mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            source=source, image_shape=image.shape
+            camera_displays_data=camera_displays_data, image_shape=image.shape
         )
         data_for_hist = image[
             ~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain
@@ -793,7 +795,7 @@ def compile_hover_tool_val_vs_id(pixel_data, figure):
     return figure
 
 
-def make_pixel_val_vs_id(source, parent_key, child_key):
+def make_pixel_val_vs_id(camera_displays_data, parent_key, child_key):
     """Make 1D plot of camera pixel values vs pixel id
        to fill the nested dict
        created by `make_camera_displays`
@@ -801,8 +803,10 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
 
     Parameters
     ----------
-    source : dict
-        Dictionary returned by `get_rundata`
+    camera_displays_data : dict
+        Dictionary containing camera display data extracted from source.
+        Each value is a dict with child keys containing 2D image arrays.
+        This should also include BADPIX data which is needed for masking.
     parent_key : str
         Parent key to extract quantity from the dict
     child_key : str
@@ -814,13 +818,13 @@ def make_pixel_val_vs_id(source, parent_key, child_key):
         figure containing the 1D plot of camera pixel values vs pixel id
     """
 
-    image = np.nan_to_num(source[parent_key][child_key], nan=0.0)
+    image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
     if "BADPIX" in parent_key:
         image = set_bad_pixels_cap_value(image)
         min_val, max_val = 0.0, 1.0
     else:
         mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            source=source, image_shape=image.shape
+            camera_displays_data=camera_displays_data, image_shape=image.shape
         )
         min_val = (
             np.min(
@@ -1007,7 +1011,7 @@ def compile_hover_tool(display, camgeom):
 
 # TODO: some more explanation about the parent and child keys
 # may help the user, if needed
-def make_camera_display(source, parent_key, child_key):
+def make_camera_display(camera_displays_data, parent_key, child_key):
     """Make camera display plot to fill the nested dict
        created by `make_camera_displays`
        along with the 1D plot of camera pixel values vs pixel id
@@ -1015,8 +1019,10 @@ def make_camera_display(source, parent_key, child_key):
 
     Parameters
     ----------
-    source : dict
-        Dictionary returned by `get_rundata`
+    camera_displays_data : dict
+        Dictionary containing camera display data extracted from source.
+        Each value is a dict with child keys containing 2D image arrays.
+        This should also include BADPIX data which is needed for masking.
     parent_key : str
         Parent key to extract quantity from the dict
     child_key : str
@@ -1033,10 +1039,7 @@ def make_camera_display(source, parent_key, child_key):
           control (None for BADPIX displays)
     """
 
-    # TODO: may want to check here to implement
-    # the "on_pixel_clicked" function for pixels
-    # ctapipe.readthedocs.io/en/stable/api/ctapipe.visualization.CameraDisplay.html
-    image = np.nan_to_num(source[parent_key][child_key], nan=0.0)
+    image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
 
     if "BADPIX" in parent_key:
         image = set_bad_pixels_cap_value(image)
@@ -1044,7 +1047,7 @@ def make_camera_display(source, parent_key, child_key):
         min_slider, max_slider = 0.0, 1.0
     else:
         mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            source=source, image_shape=image.shape
+            camera_displays_data=camera_displays_data, image_shape=image.shape
         )
         # plotting by default range with 99.5% of all events, so that
         # outliers do not prevent us from seing the bulk of the data
@@ -1165,14 +1168,16 @@ def set_bad_pixels_cap_value(image):
     return image
 
 
-def get_bad_pixels_position(source, image_shape):
+def get_bad_pixels_position(camera_displays_data, image_shape):
     """Get the positions of the bad pixels
        in the camera as boolean masks
 
     Parameters
     ----------
-    source : dict
-        Dictionary returned by `get_rundata`
+    camera_displays_data : dict
+        Dictionary containing camera display data extracted from source.
+        Each value is a dict with child keys containing 2D image arrays.
+        This should also include BADPIX data which is needed for masking.
     image_shape : tuple
         Shape of the display image
         for the quantity called in `make_camera_display`
@@ -1188,20 +1193,20 @@ def get_bad_pixels_position(source, image_shape):
     """
 
     try:
-        if "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN" in source.keys():
-            image_badpix_high_gain = source[
+        if "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN" in camera_displays_data.keys():
+            image_badpix_high_gain = camera_displays_data[
                 "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN"
             ]["CAMERA-BadPix-PED-PHY-OverEVENTS-HIGH-GAIN"]
-            image_badpix_low_gain = source[
+            image_badpix_low_gain = camera_displays_data[
                 "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN"
             ]["CAMERA-BadPix-PED-PHY-OverEVENTS-HIGH-GAIN"]
-        elif "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN" in source.keys():
-            image_badpix_high_gain = source["CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"][
-                "CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"
-            ]
-            image_badpix_low_gain = source["CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"][
-                "CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"
-            ]
+        elif "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN" in camera_displays_data.keys():
+            image_badpix_high_gain = camera_displays_data[
+                "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"
+            ]["CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"]
+            image_badpix_low_gain = camera_displays_data[
+                "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"
+            ]["CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"]
 
         mask_bad_pixels_high_gain = image_badpix_high_gain >= 1.0
         # FIXME: bad pixels for High and Low gain may be the same


### PR DESCRIPTION
fix(src/nectarchain/dqm/bokeh_app): - app_hooks.py: updated leftover source argument, and docstrings, in make_camera_display function (plus other functions called by the latter) with camera_displays_data

This PR renames the `source` argument in `make_camera_display`, `make_pixel_val_vs_id`, and `make_pixel_vals_histo` to `camera_displays_data` to respect the nomenclature. Corresponding docstrings are also updated. This does not change the code workflow, but I believe it is cleaner this way.