### PR TITLE
Bokeh add plot camera ping pong changes

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -593,7 +593,7 @@ def make_camera_displays(camera_displays_data, runid):
             )
             displays_to_show = [camera_display]
 
-            if "BADPIX" not in parentkey:
+            if "BADPIX" not in parentkey and "PING-PONG" not in parentkey:
                 if range_slider is not None:
                     displays_to_show.append(range_slider)
                 camera_pixel_val_vs_id = make_pixel_val_vs_id(
@@ -692,16 +692,12 @@ def make_pixel_vals_histo(camera_displays_data, parent_key, child_key):
 
     image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
 
-    if "BADPIX" in parent_key:
-        image = set_bad_pixels_cap_value(image)
-        data_for_hist = image
-    else:
-        mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            camera_displays_data=camera_displays_data, image_shape=image.shape
-        )
-        data_for_hist = image[
-            ~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain
-        ]
+    mask_high_gain, mask_low_gain = get_bad_pixels_position(
+        camera_displays_data=camera_displays_data, image_shape=image.shape
+    )
+    data_for_hist = image[
+        ~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain
+    ]
 
     # Use adaptive binning on full data to include outliers
     hist, bins = np.histogram(data_for_hist, bins="fd")
@@ -819,25 +815,17 @@ def make_pixel_val_vs_id(camera_displays_data, parent_key, child_key):
     """
 
     image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
-    if "BADPIX" in parent_key:
-        image = set_bad_pixels_cap_value(image)
-        min_val, max_val = 0.0, 1.0
-    else:
-        mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            camera_displays_data=camera_displays_data, image_shape=image.shape
-        )
-        min_val = (
-            np.min(
-                image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain]
-            )
-            * 0.99
-        )
-        max_val = (
-            np.max(
-                image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain]
-            )
-            * 1.01
-        )
+    mask_high_gain, mask_low_gain = get_bad_pixels_position(
+        camera_displays_data=camera_displays_data, image_shape=image.shape
+    )
+    min_val = (
+        np.min(image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain])
+        * 0.99
+    )
+    max_val = (
+        np.max(image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain])
+        * 1.01
+    )
 
     with open(labels_path, "r", encoding="utf-8") as file:
         colorbar_labels = json.load(file)["colorbar_labels_camera_display"]
@@ -903,10 +891,11 @@ def define_dymanic_color_range(
     Returns
     -------
     bokeh.models.RangeSlider or None
-        RangeSlider widget for dynamic color range control (None for BADPIX displays)
+        RangeSlider widget for dynamic color range control
+        (None for BADPIX and PING-PONG displays)
     """
 
-    if "BADPIX" not in parent_key:
+    if "BADPIX" not in parent_key and "PING-PONG" not in parent_key:
         min_slider, max_slider = min_max_slider
         min_colorbar, max_colorbar = min_max_colorbar
 
@@ -1049,31 +1038,40 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
         mask_high_gain, mask_low_gain = get_bad_pixels_position(
             camera_displays_data=camera_displays_data, image_shape=image.shape
         )
-        # plotting by default range with 99.5% of all events, so that
-        # outliers do not prevent us from seing the bulk of the data
-        min_colorbar = np.nanquantile(
-            image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain],
-            0.005,
-        )
-        max_colorbar = np.nanquantile(
-            image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain],
-            0.995,
-        )
-        min_slider = np.min(
-            image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain]
-        )
-        max_slider = np.max(
-            image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain]
-        )
-        if max_colorbar == min_colorbar:
-            # avoid problems with bokeh display
-            max_colorbar *= 1.05
-            min_colorbar *= 0.95
-        if max_slider == min_slider:
-            # avoid problems with the slider definition
-            max_slider *= 1.05
-            min_slider *= 0.95
-        image[mask_low_gain if "LOW-GAIN" in parent_key else mask_high_gain] = 0.0
+        if "PING-PONG" not in parent_key:
+            # plotting by default range with 99.5% of all events, so that
+            # outliers do not prevent us from seing the bulk of the data
+            min_colorbar = np.nanquantile(
+                image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain],
+                0.005,
+            )
+            max_colorbar = np.nanquantile(
+                image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain],
+                0.995,
+            )
+            min_slider = np.min(
+                image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain]
+            )
+            max_slider = np.max(
+                image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain]
+            )
+            if max_colorbar == min_colorbar:
+                # avoid problems with bokeh display
+                max_colorbar *= 1.05
+                min_colorbar *= 0.95
+            if max_slider == min_slider:
+                # avoid problems with the slider definition
+                max_slider *= 1.05
+                min_slider *= 0.95
+            image[mask_low_gain if "LOW-GAIN" in parent_key else mask_high_gain] = 0.0
+        else:
+            min_colorbar, max_colorbar = 0, np.max(image)
+            if max_colorbar == min_colorbar:
+                max_colorbar = 1.0
+            min_slider, max_slider = 0, np.max(image)
+            if max_slider == min_slider:
+                max_slider = 1.0
+            image[mask_low_gain] = 0.0
 
     display = CameraDisplay(geometry=geom)
     try:
@@ -1168,16 +1166,14 @@ def set_bad_pixels_cap_value(image):
     return image
 
 
-def get_bad_pixels_position(camera_displays_data, image_shape):
+def get_bad_pixels_position(source, image_shape):
     """Get the positions of the bad pixels
        in the camera as boolean masks
 
     Parameters
     ----------
-    camera_displays_data : dict
-        Dictionary containing camera display data extracted from source.
-        Each value is a dict with child keys containing 2D image arrays.
-        This should also include BADPIX data which is needed for masking.
+    source : dict
+        Dictionary returned by `get_rundata`
     image_shape : tuple
         Shape of the display image
         for the quantity called in `make_camera_display`
@@ -1193,20 +1189,20 @@ def get_bad_pixels_position(camera_displays_data, image_shape):
     """
 
     try:
-        if "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN" in camera_displays_data.keys():
-            image_badpix_high_gain = camera_displays_data[
+        if "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN" in source.keys():
+            image_badpix_high_gain = source[
                 "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN"
             ]["CAMERA-BadPix-PED-PHY-OverEVENTS-HIGH-GAIN"]
-            image_badpix_low_gain = camera_displays_data[
+            image_badpix_low_gain = source[
                 "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN"
             ]["CAMERA-BadPix-PED-PHY-OverEVENTS-HIGH-GAIN"]
-        elif "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN" in camera_displays_data.keys():
-            image_badpix_high_gain = camera_displays_data[
-                "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"
-            ]["CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"]
-            image_badpix_low_gain = camera_displays_data[
-                "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"
-            ]["CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"]
+        elif "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN" in source.keys():
+            image_badpix_high_gain = source["CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"][
+                "CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"
+            ]
+            image_badpix_low_gain = source["CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"][
+                "CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"
+            ]
 
         mask_bad_pixels_high_gain = image_badpix_high_gain >= 1.0
         # FIXME: bad pixels for High and Low gain may be the same

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -869,7 +869,7 @@ def make_pixel_val_vs_id(camera_displays_data, parent_key, child_key):
     return scatter_value_vs_id
 
 
-def define_dymanic_color_range(
+def define_dynamic_color_range(
     parent_key, display, min_max_slider, min_max_colorbar, color_bar
 ):
     """Define dynamic color range for the camera displays using a RangeSlider widget
@@ -1132,7 +1132,7 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
     display.figure.title = child_key
 
     # Create RangeSlider for dynamic color range control
-    range_slider = define_dymanic_color_range(
+    range_slider = define_dynamic_color_range(
         parent_key=parent_key,
         display=display,
         min_max_slider=(min_slider, max_slider),

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -693,7 +693,7 @@ def make_pixel_vals_histo(camera_displays_data, parent_key, child_key):
     image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
 
     mask_high_gain, mask_low_gain = get_bad_pixels_position(
-        source=camera_displays_data, image_shape=image.shape
+        camera_displays_data=camera_displays_data, image_shape=image.shape
     )
     data_for_hist = image[
         ~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain
@@ -816,7 +816,7 @@ def make_pixel_val_vs_id(camera_displays_data, parent_key, child_key):
 
     image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
     mask_high_gain, mask_low_gain = get_bad_pixels_position(
-        source=camera_displays_data, image_shape=image.shape
+        camera_displays_data=camera_displays_data, image_shape=image.shape
     )
     min_val = (
         np.min(image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain])
@@ -1036,7 +1036,7 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
         min_slider, max_slider = 0.0, 1.0
     else:
         mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            source=camera_displays_data, image_shape=image.shape
+            camera_displays_data=camera_displays_data, image_shape=image.shape
         )
         if "PING-PONG" not in parent_key:
             # plotting by default range with 99.5% of all events, so that
@@ -1166,14 +1166,16 @@ def set_bad_pixels_cap_value(image):
     return image
 
 
-def get_bad_pixels_position(source, image_shape):
+def get_bad_pixels_position(camera_displays_data, image_shape):
     """Get the positions of the bad pixels
        in the camera as boolean masks
 
     Parameters
     ----------
-    source : dict
-        Dictionary returned by `get_rundata`
+    camera_displays_data : dict
+        Dictionary containing camera display data extracted from source.
+        Each value is a dict with child keys containing 2D image arrays.
+        This should also include BADPIX data which is needed for masking.
     image_shape : tuple
         Shape of the display image
         for the quantity called in `make_camera_display`
@@ -1189,20 +1191,20 @@ def get_bad_pixels_position(source, image_shape):
     """
 
     try:
-        if "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN" in source.keys():
-            image_badpix_high_gain = source[
+        if "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN" in camera_displays_data.keys():
+            image_badpix_high_gain = camera_displays_data[
                 "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN"
             ]["CAMERA-BadPix-PED-PHY-OverEVENTS-HIGH-GAIN"]
-            image_badpix_low_gain = source[
+            image_badpix_low_gain = camera_displays_data[
                 "CAMERA-BADPIX-PED-PHY-OVEREVENTS-HIGH-GAIN"
             ]["CAMERA-BadPix-PED-PHY-OverEVENTS-HIGH-GAIN"]
-        elif "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN" in source.keys():
-            image_badpix_high_gain = source["CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"][
-                "CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"
-            ]
-            image_badpix_low_gain = source["CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"][
-                "CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"
-            ]
+        elif "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN" in camera_displays_data.keys():
+            image_badpix_high_gain = camera_displays_data[
+                "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"
+            ]["CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"]
+            image_badpix_low_gain = camera_displays_data[
+                "CAMERA-BADPIX-PHY-OVEREVENTS-HIGH-GAIN"
+            ]["CAMERA-BadPix-PHY-OverEVENTS-HIGH-GAIN"]
 
         mask_bad_pixels_high_gain = image_badpix_high_gain >= 1.0
         # FIXME: bad pixels for High and Low gain may be the same

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -693,7 +693,7 @@ def make_pixel_vals_histo(camera_displays_data, parent_key, child_key):
     image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
 
     mask_high_gain, mask_low_gain = get_bad_pixels_position(
-        camera_displays_data=camera_displays_data, image_shape=image.shape
+        source=camera_displays_data, image_shape=image.shape
     )
     data_for_hist = image[
         ~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain
@@ -816,7 +816,7 @@ def make_pixel_val_vs_id(camera_displays_data, parent_key, child_key):
 
     image = np.nan_to_num(camera_displays_data[parent_key][child_key], nan=0.0)
     mask_high_gain, mask_low_gain = get_bad_pixels_position(
-        camera_displays_data=camera_displays_data, image_shape=image.shape
+        source=camera_displays_data, image_shape=image.shape
     )
     min_val = (
         np.min(image[~mask_low_gain if "LOW-GAIN" in parent_key else ~mask_high_gain])
@@ -1036,7 +1036,7 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
         min_slider, max_slider = 0.0, 1.0
     else:
         mask_high_gain, mask_low_gain = get_bad_pixels_position(
-            camera_displays_data=camera_displays_data, image_shape=image.shape
+            source=camera_displays_data, image_shape=image.shape
         )
         if "PING-PONG" not in parent_key:
             # plotting by default range with 99.5% of all events, so that

--- a/src/nectarchain/dqm/bokeh_app/data/labels.json
+++ b/src/nectarchain/dqm/bokeh_app/data/labels.json
@@ -44,7 +44,8 @@
         "CHARGE-INTEGRATION-IMAGE-ALL-RMS-HIGH-GAIN": "ADC counts",
         "CHARGE-INTEGRATION-IMAGE-ALL-RMS-LOW-GAIN": "ADC counts",
         "CHARGE-INTEGRATION-IMAGE-ALL-STD-HIGH-GAIN": "ADC counts",
-        "CHARGE-INTEGRATION-IMAGE-ALL-STD-LOW-GAIN": "ADC counts"
+        "CHARGE-INTEGRATION-IMAGE-ALL-STD-LOW-GAIN": "ADC counts",
+        "CAMERA-PING-PONG-CHANGES": "# of ping pong changes"
     },
     "section_titles_camera_display": {
         "TEMPERATURE": "Camera Temperature",

--- a/src/nectarchain/dqm/bokeh_app/extract_data.py
+++ b/src/nectarchain/dqm/bokeh_app/extract_data.py
@@ -7,7 +7,7 @@ logger = setup_logger()
 
 
 NOTINCAMERADISPLAY = [
-    "CAMERA-PING-PONG-.*",
+    "CAMERA-PING-PONG-CHANGES-TIMES",
     "TRIGGER-.*",
     "PED-INTEGRATION-.*",
     "START-TIMES",


### PR DESCRIPTION
feat(src/nectarchain/dqm/bokeh_app):
- app_hooks.py: add CAMERA-PING-PONG-CHANGES among the camera displays and remove old obsolete if clauses
- extract_data.py: adapt TEST_PATTERN to let categorize_source_data find the ping pong data
- data/labels.json: add colorbar label for ping pong plot

This PR adds the number of ping pong changes as a camera display plot. CAMERA-PING-PONG-CHANGES comes with CAMERA-PING-PONG-CHANGES-TIMES. The latter is not yet included in the plots, but it shall be in a later PR, because I think it is worth displaying only if there are actually more than 0 changes in the other array. 