### PR TITLE
Clean Singularity/Apptainer cache at the end of DIRAC DQM jobs

### DIFF
--- a/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/dqm_processor.sh
+++ b/src/nectarchain/user_scripts/jlenain/dqm_job_submitter/dqm_processor.sh
@@ -119,6 +119,11 @@ echo "Running"
 cmd="\$CALLER exec --home $PWD $CONTAINER /opt/conda/envs/nectarchain/bin/python /opt/cta/nectarchain/src/nectarchain/dqm/start_dqm.py --r0 --runnb $runnb --camera $camera $NECTARCAMDATA $NECTARDIR"
 echo \$cmd
 eval \$cmd
+
+# Clean Singularity/Apptainer cache behind us:
+cmd="\$CALLER cache clean --days 3 --force"
+echo \$cmd
+eval \$cmd
 EOF
 
 chmod u+x $WRAPPER || exit_script $?


### PR DESCRIPTION
Some grid sites warned me that our DQM jobs on DIRAC are letting some leftover in the local $HOME directory on worker nodes, most presumably coming from the Apptainer image cached locally when instantiating our containers there.

This PR adds a cleaning of the Apptainer cache before leaving production.