### PR TITLE
Bokeh, add pixel tap tool to display waveforms

### DIFF
--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -998,6 +998,88 @@ def compile_hover_tool(display, camgeom):
     return display
 
 
+class CameraDisplayNectarCAM(CameraDisplay):
+    """Overrides the pixel picker callback to customize handling"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.colorbar_label = ""
+        self.figure_title = ""
+        self.selected_pixel_waveform = column(sizing_mode="scale_width")
+        self.source = None
+        self.parent_key = None
+        self.child_key = None
+
+    def pixel_picker_callback(self, attr, old, new):
+        """Callback for when pixels are selected
+
+        Parameters
+        ----------
+        attr : str
+            Attribute name (always 'indices')
+        old : list
+            Previously selected pixel indices
+        new : list
+            Currently selected pixel indices
+        """
+        with open(labels_path, "r", encoding="utf-8") as file:
+            y_axis_labels = json.load(file)["y_axis_labels_waveforms"]
+
+        for pix_id in new:
+            logger.info(
+                f"{self.figure_title} - {pix_id=} has value"
+                + f" {self.image[pix_id]:.2f} [{self.colorbar_label}]"
+            )
+
+            # Create or update a plot that is shown next to the tapped camera display.
+            # This is the right pattern: update an existing placeholder inside the
+            # layout instead of adding a new root at the bottom of the document.
+            samples = np.arange(len(self.source[self.parent_key][self.child_key]))
+            waveform = self.source[self.parent_key][self.child_key]
+            waveform_plot = figure(
+                title=self.child_key + f", selected pixel {pix_id}",
+                x_range=(np.min(samples) - 5, np.max(samples) + 5),
+                y_range=(
+                    np.min(waveform) - np.min(waveform) / 100,
+                    np.max(waveform) + np.max(waveform) / 100,
+                ),
+            )
+            waveform_plot.line(
+                x=samples,
+                y=waveform,
+                line_width=3,
+            )
+            try:
+                waveform_plot.yaxis.axis_label = y_axis_labels[self.parent_key]
+            except ValueError:
+                waveform_plot.yaxis.axis_label = ""
+            except KeyError:
+                waveform_plot.yaxis.axis_label = ""
+
+            waveform_plot.xaxis.axis_label_text_font_size = "12pt"
+            waveform_plot.yaxis.axis_label_text_font_size = "12pt"
+            waveform_plot.xaxis.major_label_text_font_size = "10pt"
+            waveform_plot.yaxis.major_label_text_font_size = "10pt"
+            waveform_plot.xaxis.axis_label_text_font_style = "normal"
+            waveform_plot.yaxis.axis_label_text_font_style = "normal"
+
+            self.selected_pixel_waveform.children = [waveform_plot]
+
+        # TODO: possible workflow could be:
+        # 1. access to the data and plots (waveforms, timelines, etc.)
+        # from within the callback adding self.source parent and child keys
+        # as attributes
+        # 2. modify the callback to generate plots, for instance the waveform
+        # plot for the selected pixel
+        # 3. add plots to the root self.document.add_root(p)
+        # 4. clear old plots whenever a new pixel is tapped
+        # for p in self.pixel_plots.values(): self.document.remove_root(p)
+        # 5. understand where to place these plots, either in another tab,
+        # or show this plot in
+        # the same row as the Camera Display only when it is not empty....
+        # CHECK THE CONVERSATION WITH MISTRAL
+
+
 # TODO: some more explanation about the parent and child keys
 # may help the user, if needed
 def make_camera_display(camera_displays_data, parent_key, child_key):
@@ -1073,7 +1155,8 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
                 max_slider = 1.0
             image[mask_low_gain] = 0.0
 
-    display = CameraDisplay(geometry=geom)
+    # display = CameraDisplay(geometry=geom)
+    display = CameraDisplayNectarCAM(geom)
     try:
         display.image = image
     except ValueError as e:
@@ -1124,12 +1207,22 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
 
     try:
         color_bar.title = colorbar_labels[parent_key]
+        display.colorbar_label = colorbar_labels[parent_key]
     except ValueError:
         color_bar.title = ""
+        display.colorbar_label = ""
     except KeyError:
         color_bar.title = ""
+        display.colorbar_label = ""
 
     display.figure.title = child_key
+    display.figure_title = child_key
+    display.selected_pixel_waveform = column(sizing_mode="scale_width")
+    display.source = source
+    display.parent_key = "WF-PHY-AVERAGE-PIX-HIGH-GAIN"
+    display.child_key = "WF-PHY-AVERAGE-PIX-HIGH-GAIN"
+
+    display.enable_pixel_picker(display.pixel_picker_callback)
 
     # Create RangeSlider for dynamic color range control
     range_slider = define_dynamic_color_range(

--- a/src/nectarchain/dqm/bokeh_app/app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/app_hooks.py
@@ -564,7 +564,7 @@ def update_timelines(timelines_data, runid=None):
     return tab_timelines
 
 
-def make_camera_displays(camera_displays_data, runid):
+def make_camera_displays(camera_displays_data, runid, waveforms_data=None):
     """Make camera display plots using `make_camera_display`,
        `make_pixel_val_vs_id` and `make_pixel_vals_histo`
 
@@ -577,6 +577,10 @@ def make_camera_displays(camera_displays_data, runid):
     runid : str
         Identifier for dictionary extracted from the database,
         containing the NectarCAM run number. Example: 'NectarCAMQM_Run6310'.
+    waveforms_data : dict, optional
+        Dictionary containing categorized waveform data with 'average' and 'all' keys.
+        Used to display individual pixel waveforms when a pixel is tapped.
+        By default None
 
     Returns
     -------
@@ -589,7 +593,10 @@ def make_camera_displays(camera_displays_data, runid):
         for childkey in parent_data.keys():
             logger.info(f"Run id {runid}, preparing plot for {parentkey}, {childkey}")
             camera_display, range_slider = make_camera_display(
-                camera_displays_data, parent_key=parentkey, child_key=childkey
+                camera_displays_data,
+                parent_key=parentkey,
+                child_key=childkey,
+                waveforms_data=waveforms_data,
             )
             displays_to_show = [camera_display]
 
@@ -612,7 +619,7 @@ def make_camera_displays(camera_displays_data, runid):
     return dict(displays)
 
 
-def update_camera_displays(camera_displays_data, runid=None):
+def update_camera_displays(camera_displays_data, runid=None, waveforms_data=None):
     """Reset each display previously created by `make_camera_displays`
 
     Parameters
@@ -625,6 +632,10 @@ def update_camera_displays(camera_displays_data, runid=None):
         Identifier for dictionary extracted from the database,
         containing the NectarCAM run number. Example: 'NectarCAMQM_Run6310'.
         By default None
+    waveforms_data : dict, optional
+        Dictionary containing categorized waveform data with 'average' and 'all' keys.
+        Used to display individual pixel waveforms when a pixel is tapped.
+        By default None
 
     Returns
     -------
@@ -633,7 +644,9 @@ def update_camera_displays(camera_displays_data, runid=None):
     """
 
     # Make new camera display plots
-    displays = make_camera_displays(camera_displays_data, runid)
+    displays = make_camera_displays(
+        camera_displays_data, runid, waveforms_data=waveforms_data
+    )
 
     camera_displays = [
         (
@@ -645,10 +658,14 @@ def update_camera_displays(camera_displays_data, runid=None):
                         displays[parentkey][childkey][2],
                         displays[parentkey][childkey][3],
                     ),
+                    displays[parentkey][childkey][0].selected_pixel_waveform,
                 ]
             )
             if len(displays[parentkey][childkey]) == 4
-            else displays[parentkey][childkey][0].figure
+            else column(
+                displays[parentkey][childkey][0].figure,
+                displays[parentkey][childkey][0].selected_pixel_waveform,
+            )
         )
         for parentkey in displays.keys()
         for childkey in displays[parentkey].keys()
@@ -1005,10 +1022,11 @@ class CameraDisplayNectarCAM(CameraDisplay):
         super().__init__(*args, **kwargs)
         self.colorbar_label = ""
         self.figure_title = ""
-        self.selected_pixel_waveform = column(sizing_mode="scale_width")
-        self.source = None
+        self.selected_pixel_waveform = row(sizing_mode="scale_width")
+        self.camera_displays_data = None
         self.parent_key = None
         self.child_key = None
+        self.waveforms_data = None
 
     def pixel_picker_callback(self, attr, old, new):
         """Callback for when pixels are selected
@@ -1030,59 +1048,119 @@ class CameraDisplayNectarCAM(CameraDisplay):
                 f"{self.figure_title} - {pix_id=} has value"
                 + f" {self.image[pix_id]:.2f} [{self.colorbar_label}]"
             )
+            selected_waveform_plots = []
 
             # Create or update a plot that is shown next to the tapped camera display.
             # This is the right pattern: update an existing placeholder inside the
             # layout instead of adding a new root at the bottom of the document.
-            samples = np.arange(len(self.source[self.parent_key][self.child_key]))
-            waveform = self.source[self.parent_key][self.child_key]
-            waveform_plot = figure(
-                title=self.child_key + f", selected pixel {pix_id}",
-                x_range=(np.min(samples) - 5, np.max(samples) + 5),
-                y_range=(
-                    np.min(waveform) - np.min(waveform) / 100,
-                    np.max(waveform) + np.max(waveform) / 100,
-                ),
-            )
-            waveform_plot.line(
-                x=samples,
-                y=waveform,
-                line_width=3,
-            )
-            try:
-                waveform_plot.yaxis.axis_label = y_axis_labels[self.parent_key]
-            except ValueError:
-                waveform_plot.yaxis.axis_label = ""
-            except KeyError:
-                waveform_plot.yaxis.axis_label = ""
+            if self.waveforms_data:
+                # get average waveform from waveforms_data
+                avg_waveforms_dict = self.waveforms_data["average"]
+                all_waveforms_dict = self.waveforms_data["all"]
 
-            waveform_plot.xaxis.axis_label_text_font_size = "12pt"
-            waveform_plot.yaxis.axis_label_text_font_size = "12pt"
-            waveform_plot.xaxis.major_label_text_font_size = "10pt"
-            waveform_plot.yaxis.major_label_text_font_size = "10pt"
-            waveform_plot.xaxis.axis_label_text_font_style = "normal"
-            waveform_plot.yaxis.axis_label_text_font_style = "normal"
+                colors_phy = ["blue", "turquoise"]
+                colors_ped = ["red", "orange"]
 
-            self.selected_pixel_waveform.children = [waveform_plot]
+                for parentkey in avg_waveforms_dict.keys():
+                    colors = colors_phy if "PHY" in parentkey else colors_ped
 
-        # TODO: possible workflow could be:
-        # 1. access to the data and plots (waveforms, timelines, etc.)
-        # from within the callback adding self.source parent and child keys
-        # as attributes
-        # 2. modify the callback to generate plots, for instance the waveform
-        # plot for the selected pixel
-        # 3. add plots to the root self.document.add_root(p)
-        # 4. clear old plots whenever a new pixel is tapped
-        # for p in self.pixel_plots.values(): self.document.remove_root(p)
-        # 5. understand where to place these plots, either in another tab,
-        # or show this plot in
-        # the same row as the Camera Display only when it is not empty....
-        # CHECK THE CONVERSATION WITH MISTRAL
+                    # Find corresponding all_waveforms key by removing -AVERAGE-
+                    all_parentkey = parentkey.replace("-AVERAGE-PIX", "")
+
+                    for childkey in avg_waveforms_dict[parentkey].keys():
+                        all_childkey = childkey.replace("-AVERAGE-PIX", "")
+
+                        samples = np.arange(
+                            len(avg_waveforms_dict[parentkey][childkey])
+                        )
+                        avg_waveform = avg_waveforms_dict[parentkey][childkey]
+
+                        # Determine y-range from average waveform first
+                        y_min = (
+                            np.min(avg_waveform) - np.abs(np.min(avg_waveform)) * 0.1
+                        )
+                        y_max = (
+                            np.max(avg_waveform) + np.abs(np.max(avg_waveform)) * 0.1
+                        )
+
+                        pixel_waveform = all_waveforms_dict[all_parentkey][
+                            all_childkey
+                        ][pix_id]
+                        y_min = min(
+                            y_min,
+                            np.min(pixel_waveform)
+                            - np.abs(np.min(pixel_waveform)) * 0.1,
+                        )
+                        y_max = max(
+                            y_max,
+                            np.max(pixel_waveform)
+                            + np.abs(np.max(pixel_waveform)) * 0.1,
+                        )
+
+                        waveform_plot = figure(
+                            title=all_childkey + f", selected pixel {pix_id}",
+                            x_range=(np.min(samples) - 5, np.max(samples) + 5),
+                            y_range=(y_min, y_max),
+                            width=400,
+                            height=400,
+                        )
+
+                        # Plot average waveform
+                        waveform_plot.line(
+                            x=samples,
+                            y=avg_waveform,
+                            line_width=3,
+                            color=colors[0],
+                            legend_label="Average",
+                        )
+                        waveform_plot.line(
+                            x=samples,
+                            y=pixel_waveform,
+                            line_width=2,
+                            color=colors[1],
+                            legend_label=f"Pixel {pix_id}",
+                        )
+
+                        waveform_plot.xaxis.axis_label = "Waveform sample number"
+
+                        try:
+                            waveform_plot.yaxis.axis_label = y_axis_labels[parentkey]
+                        except ValueError:
+                            waveform_plot.yaxis.axis_label = ""
+                        except KeyError:
+                            waveform_plot.yaxis.axis_label = ""
+
+                        waveform_plot.xaxis.axis_label_text_font_size = "12pt"
+                        waveform_plot.yaxis.axis_label_text_font_size = "12pt"
+                        waveform_plot.xaxis.major_label_text_font_size = "10pt"
+                        waveform_plot.yaxis.major_label_text_font_size = "10pt"
+                        waveform_plot.xaxis.axis_label_text_font_style = "normal"
+                        waveform_plot.yaxis.axis_label_text_font_style = "normal"
+
+                        waveform_plot.outline_line_color = "navy"
+
+                        logger.info(
+                            f"Added {parentkey} and {childkey} "
+                            + f"for {pix_id=}, to the display"
+                        )
+
+                        selected_waveform_plots.append(waveform_plot)
+
+                self.selected_pixel_waveform.children = selected_waveform_plots
+
+            else:
+                avg_waveform = None
+
+            if avg_waveform is None:
+                logger.warning("No waveform data found to add to the display")
+                return
 
 
 # TODO: some more explanation about the parent and child keys
 # may help the user, if needed
-def make_camera_display(camera_displays_data, parent_key, child_key):
+def make_camera_display(
+    camera_displays_data, parent_key, child_key, waveforms_data=None
+):
     """Make camera display plot to fill the nested dict
        created by `make_camera_displays`
        along with the 1D plot of camera pixel values vs pixel id
@@ -1098,6 +1176,10 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
         Parent key to extract quantity from the dict
     child_key : str
         Child key to extract quantity from the dict
+    waveforms_data : dict, optional
+        Dictionary containing categorized waveform data with 'average' and 'all' keys.
+        Used to display individual pixel waveforms when a pixel is tapped.
+        By default None
 
     Returns
     -------
@@ -1217,10 +1299,12 @@ def make_camera_display(camera_displays_data, parent_key, child_key):
 
     display.figure.title = child_key
     display.figure_title = child_key
-    display.selected_pixel_waveform = column(sizing_mode="scale_width")
-    display.source = source
-    display.parent_key = "WF-PHY-AVERAGE-PIX-HIGH-GAIN"
-    display.child_key = "WF-PHY-AVERAGE-PIX-HIGH-GAIN"
+    display.selected_pixel_waveform = row(sizing_mode="scale_width")
+    display.selected_pixel_waveform_plots = []
+    display.camera_displays_data = camera_displays_data
+    display.parent_key = parent_key
+    display.child_key = child_key
+    display.waveforms_data = waveforms_data
 
     display.enable_pixel_picker(display.pixel_picker_callback)
 

--- a/src/nectarchain/dqm/bokeh_app/main.py
+++ b/src/nectarchain/dqm/bokeh_app/main.py
@@ -78,7 +78,9 @@ def get_layout_per_camera(source, runids, camera_code):
         categorized = categorize_source_data(source)
 
         tab_camera_displays = update_camera_displays(
-            categorized["camera_displays"], runid
+            categorized["camera_displays"],
+            runid,
+            waveforms_data=categorized["waveforms"],
         )
         tab_timelines = update_timelines(categorized["timelines"], runid)
         tab_waveforms = update_waveforms(categorized["waveforms"], runid)
@@ -155,7 +157,9 @@ def get_layout_per_camera(source, runids, camera_code):
     requested_at_time = time.time()
     source = get_rundata(db, run_select.value)
     categorized = categorize_source_data(source)
-    displays = make_camera_displays(categorized["camera_displays"], runid)
+    displays = make_camera_displays(
+        categorized["camera_displays"], runid, waveforms_data=categorized["waveforms"]
+    )
     timelines = make_timelines(categorized["timelines"], runid)
     waveforms = make_waveforms(categorized["waveforms"], runid)
     trig_timestamps = make_trigger_timestamps_vs_ids(
@@ -204,10 +208,14 @@ def get_layout_per_camera(source, runids, camera_code):
                     displays[parentkey][childkey][2],
                     displays[parentkey][childkey][3],
                 ),
+                displays[parentkey][childkey][0].selected_pixel_waveform,
             ]
         )
         if len(displays[parentkey][childkey]) == 4
-        else displays[parentkey][childkey][0].figure
+        else column(
+            displays[parentkey][childkey][0].figure,
+            displays[parentkey][childkey][0].selected_pixel_waveform,
+        )
         for parentkey in displays.keys()
         for childkey in displays[parentkey].keys()
     ]

--- a/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
+++ b/src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py
@@ -412,3 +412,189 @@ def test_compile_hover_tool_val_vs_id():
 
     # Verify the scatter plot is in the renderers
     assert scatter in custom_hover_tool.renderers
+
+
+def test_camera_display_initialization():
+    """Test CameraDisplayNectarCAM class initialization"""
+    from nectarchain.dqm.bokeh_app.app_hooks import CameraDisplayNectarCAM
+
+    # Create a CameraDisplayNectarCAM instance
+    display = CameraDisplayNectarCAM(geometry=geom)
+
+    # Verify that it inherits from CameraDisplay
+    from ctapipe.visualization.bokeh import CameraDisplay
+
+    assert isinstance(display, CameraDisplay)
+
+    # Verify that all custom attributes are initialized
+    assert hasattr(display, "colorbar_label")
+    assert hasattr(display, "figure_title")
+    assert hasattr(display, "selected_pixel_waveform")
+    assert hasattr(display, "camera_displays_data")
+    assert hasattr(display, "parent_key")
+    assert hasattr(display, "child_key")
+    assert hasattr(display, "waveforms_data")
+
+    # Verify initial values
+    assert display.colorbar_label == ""
+    assert display.figure_title == ""
+    assert display.camera_displays_data is None
+    assert display.parent_key is None
+    assert display.child_key is None
+    assert display.waveforms_data is None
+
+    # Verify that selected_pixel_waveform is a bokeh row
+    from bokeh.models.layouts import Row
+
+    assert isinstance(display.selected_pixel_waveform, Row)
+
+
+def test_camera_display_pixel_picker_callback_no_waveforms():
+    """Test pixel_picker_callback when no waveforms_data is available"""
+    from nectarchain.dqm.bokeh_app.app_hooks import CameraDisplayNectarCAM
+
+    # Create a CameraDisplayNectarCAM instance
+    display = CameraDisplayNectarCAM(geometry=geom)
+    display.image = np.random.normal(size=geom.n_pixels)
+    display.figure_title = "Test Display"
+    display.colorbar_label = "Test Units"
+
+    # Set waveforms_data to None to test the no data case
+    display.waveforms_data = None
+
+    # Mock the logger to capture the warning message
+    from unittest.mock import patch
+
+    with patch("nectarchain.dqm.bokeh_app.app_hooks.logger") as mock_logger:
+        # Call the pixel picker callback with some pixel indices
+        display.pixel_picker_callback("indices", [], [0, 1, 2])
+
+        # Verify that warning was logged
+        mock_logger.warning.assert_called_once()
+        warning_call = mock_logger.warning.call_args[0]
+        assert "No waveform data found to add to the display" in warning_call[0]
+
+
+def test_camera_display_pixel_picker_callback_with_waveforms():
+    """Test pixel_picker_callback with waveforms_data available"""
+    from bokeh.plotting import figure
+
+    from nectarchain.dqm.bokeh_app.app_hooks import CameraDisplayNectarCAM
+
+    # Create a CameraDisplayNectarCAM instance
+    display = CameraDisplayNectarCAM(geometry=geom)
+    display.image = np.random.normal(size=geom.n_pixels)
+    display.figure_title = "Test Display"
+    display.colorbar_label = "Test Units"
+
+    # Create mock waveforms data
+    n_samples = 100
+    n_pixels = geom.n_pixels
+
+    # Create average waveforms
+    avg_waveforms_dict = {
+        "WF-PHY-AVERAGE-PIX-HIGH-GAIN": {
+            "WF-PHY-AVERAGE-PIX-HIGH-GAIN": np.random.normal(size=n_samples)
+        }
+    }
+
+    # Create all waveforms
+    all_waveforms_dict = {
+        "WF-PHY-HIGH-GAIN": {
+            "WF-PHY-HIGH-GAIN": np.random.normal(size=(n_pixels, n_samples))
+        }
+    }
+
+    display.waveforms_data = {"average": avg_waveforms_dict, "all": all_waveforms_dict}
+
+    # Mock the labels.json file for y-axis labels
+    import json
+    from unittest.mock import mock_open, patch
+
+    mock_labels_data = {
+        "y_axis_labels_waveforms": {"WF-PHY-AVERAGE-PIX-HIGH-GAIN": "Test Label"}
+    }
+
+    # Mock the logger to capture info messages
+    with patch("nectarchain.dqm.bokeh_app.app_hooks.logger") as mock_logger, patch(
+        "builtins.open", mock_open(read_data=json.dumps(mock_labels_data))
+    ):
+        # Call the pixel picker callback with a pixel index
+        display.pixel_picker_callback("indices", [], [0])
+
+        # Verify that info messages were logged
+        assert (
+            mock_logger.info.call_count >= 2
+        )  # At least one for pixel value, one for adding to display
+
+        # Check the selected_pixel_waveform children were populated
+        assert len(display.selected_pixel_waveform.children) > 0
+
+        # Verify that the first child is a figure
+        first_child = display.selected_pixel_waveform.children[0]
+        assert isinstance(first_child, figure)
+
+        # Verify the figure has the expected properties
+        assert "selected pixel 0" in first_child.title.text
+
+
+def test_camera_display_pixel_picker_callback_mixed_waveforms():
+    """Test pixel_picker_callback with mixed PHY and PED waveforms"""
+    from nectarchain.dqm.bokeh_app.app_hooks import CameraDisplayNectarCAM
+
+    # Create a CameraDisplayNectarCAM instance
+    display = CameraDisplayNectarCAM(geometry=geom)
+    display.image = np.random.normal(size=geom.n_pixels)
+    display.figure_title = "Test Display"
+    display.colorbar_label = "Test Units"
+
+    # Create mock waveforms data with both PHY and PED
+    n_samples = 50
+    n_pixels = geom.n_pixels
+
+    avg_waveforms_dict = {
+        "WF-PHY-AVERAGE-PIX-HIGH-GAIN": {
+            "WF-PHY-AVERAGE-PIX-HIGH-GAIN": np.random.normal(size=n_samples)
+        },
+        "WF-PED-AVERAGE-PIX-HIGH-GAIN": {
+            "WF-PED-AVERAGE-PIX-HIGH-GAIN": np.random.normal(size=n_samples)
+        },
+    }
+
+    all_waveforms_dict = {
+        "WF-PHY-HIGH-GAIN": {
+            "WF-PHY-HIGH-GAIN": np.random.normal(size=(n_pixels, n_samples))
+        },
+        "WF-PED-HIGH-GAIN": {
+            "WF-PED-HIGH-GAIN": np.random.normal(size=(n_pixels, n_samples))
+        },
+    }
+
+    display.waveforms_data = {"average": avg_waveforms_dict, "all": all_waveforms_dict}
+
+    # Mock the labels.json file
+    import json
+    from unittest.mock import mock_open, patch
+
+    mock_labels_data = {
+        "y_axis_labels_waveforms": {
+            "WF-PHY-AVERAGE-PIX-HIGH-GAIN": "Physics Label",
+            "WF-PED-AVERAGE-PIX-HIGH-GAIN": "Pedestal Label",
+        }
+    }
+
+    with patch("nectarchain.dqm.bokeh_app.app_hooks.logger"), patch(
+        "builtins.open", mock_open(read_data=json.dumps(mock_labels_data))
+    ):
+        # Call the pixel picker callback
+        display.pixel_picker_callback("indices", [], [5])
+
+        # Check that waveforms for both PHY and PED were created
+        assert len(display.selected_pixel_waveform.children) == 2
+
+        # Verify the titles contain the expected keys
+        titles = [
+            child.title.text for child in display.selected_pixel_waveform.children
+        ]
+        assert any("WF-PHY" in title for title in titles)
+        assert any("WF-PED" in title for title in titles)


### PR DESCRIPTION
This PR implements the tap tool on all camera display plots. Once the user taps on a pixel, all the waveforms for that run are displayed on smaller figures just below the camera display. The display shows the average waveform and the waveform for the tapped pixel. The class that overrides the pixel picker callback is flexible enough such that more plots can be added in the future to the Bokeh `row` layout. 

The plots are updated when a new pixel is tapped, and removed when a new run number is chosen in the select.

Unit tests have been added to `tests/test_app_hooks.py`, and have been run in local via `python -m pytest src/nectarchain/dqm/bokeh_app/tests/test_app_hooks.py -k "camera_display" -v`: all successfull!

<img width="802" height="418" alt="image" src="https://github.com/user-attachments/assets/fc805fff-f1c0-4c81-90c5-fcb575868099" />
